### PR TITLE
[NSE-22]Fix w/DPP issue when inside wscg smj both sides are smj

### DIFF
--- a/core/src/main/scala/com/intel/oap/execution/ColumnarBasicPhysicalOperators.scala
+++ b/core/src/main/scala/com/intel/oap/execution/ColumnarBasicPhysicalOperators.scala
@@ -100,7 +100,7 @@ case class ColumnarConditionProjectExec(
       Seq(child.executeColumnar())
   }
 
-  override def getBuildPlans: Seq[SparkPlan] = child match {
+  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = child match {
     case c: ColumnarCodegenSupport if c.supportColumnarCodegen == true =>
       c.getBuildPlans
     case _ =>

--- a/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -96,12 +96,12 @@ case class ColumnarSortExec(
 
   override def supportColumnarCodegen: Boolean = true
 
-  override def getBuildPlans: Seq[SparkPlan] = child match {
+  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = child match {
     case c: ColumnarCodegenSupport if c.supportColumnarCodegen == true =>
       val childPlans = c.getBuildPlans
-      childPlans :+ this
+      childPlans :+ (this, null)
     case _ =>
-      Seq(this)
+      Seq((this, null))
   }
 
   override def getStreamedLeafPlan: SparkPlan = child match {

--- a/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -153,16 +153,7 @@ class ColumnarSorter(
           sort_elapse += System.nanoTime() - beforeSort
           total_elapse += System.nanoTime() - beforeSort
         }
-        if (has_next)
-          has_next = sort_iterator.hasNext()
-
-        if (has_next == false) {
-          //TODO(): should try to close sorter
-          //close()
-        }
-
-        return has_next
-
+        sort_iterator.hasNext()
       }
 
       override def next(): ColumnarBatch = {

--- a/cpp/src/codegen/arrow_compute/ext/conditioned_merge_join_kernel.cc
+++ b/cpp/src/codegen/arrow_compute/ext/conditioned_merge_join_kernel.cc
@@ -198,9 +198,13 @@ class ConditionedMergeJoinKernel::Impl {
 
     function_define_ss << "inline int JoinCompare_" << relation_id_[0] << "() {"
                        << std::endl;
+    function_define_ss << "if (!sort_relation_" << relation_id_[0]
+                       << "_->CheckRangeBound(0)) return -1;" << std::endl;
     function_define_ss << "auto idx_0 = sort_relation_" << relation_id_[0]
                        << "_->GetItemIndexWithShift(0);" << std::endl;
     if (use_relation_for_stream) {
+      function_define_ss << "if (!sort_relation_" << relation_id_[1]
+                         << "_->CheckRangeBound(0)) return 1;" << std::endl;
       function_define_ss << "auto idx_1 = sort_relation_" << relation_id_[1]
                          << "_->GetItemIndexWithShift(0);" << std::endl;
     }
@@ -397,11 +401,9 @@ class ConditionedMergeJoinKernel::Impl {
     codes_ss << "auto " << function_name << "_res = " << function_name << "();"
              << std::endl;
     codes_ss << "while (" << function_name << "_res < 0) {" << std::endl;
-    codes_ss << "if ((should_stop_ = !" << build_relation << "->NextNewKey())) break;"
-             << std::endl;
+    codes_ss << "if ((!" << build_relation << "->NextNewKey())) break;" << std::endl;
     codes_ss << function_name << "_res = " << function_name << "();" << std::endl;
     codes_ss << "}" << std::endl;
-    codes_ss << "if (should_stop_) break;" << std::endl;
     codes_ss << "if (" << function_name << "_res == 0) {" << std::endl;
     codes_ss << range_name << " = " << build_relation << "->GetSameKeyRange();"
              << std::endl;
@@ -480,11 +482,9 @@ class ConditionedMergeJoinKernel::Impl {
     codes_ss << "auto " << function_name << "_res = " << function_name << "();"
              << std::endl;
     codes_ss << "while (" << function_name << "_res < 0) {" << std::endl;
-    codes_ss << "if ((should_stop_ = !" << build_relation << "->NextNewKey())) break;"
-             << std::endl;
+    codes_ss << "if ((!" << build_relation << "->NextNewKey())) break;" << std::endl;
     codes_ss << function_name << "_res = " << function_name << "();" << std::endl;
     codes_ss << "}" << std::endl;
-    codes_ss << "if (should_stop_) break;" << std::endl;
     codes_ss << "if (" << function_name << "_res == 0) {" << std::endl;
     if (cond_check) {
       codes_ss << found_match_name << " = true;" << std::endl;
@@ -670,11 +670,9 @@ class ConditionedMergeJoinKernel::Impl {
     codes_ss << "auto " << function_name << "_res = " << function_name << "();"
              << std::endl;
     codes_ss << "while (" << function_name << "_res < 0) {" << std::endl;
-    codes_ss << "if ((should_stop_ = !" << build_relation << "->NextNewKey())) break;"
-             << std::endl;
+    codes_ss << "if ((!" << build_relation << "->NextNewKey())) break;" << std::endl;
     codes_ss << function_name << "_res = " << function_name << "();" << std::endl;
     codes_ss << "}" << std::endl;
-    codes_ss << "if (should_stop_) break;" << std::endl;
     codes_ss << "if (" << function_name << "_res != 0) {" << std::endl;
     codes_ss << found_match_name << " = false;" << std::endl;
     codes_ss << "} else {" << std::endl;

--- a/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
+++ b/cpp/src/codegen/arrow_compute/ext/kernels_ext.cc
@@ -1462,8 +1462,10 @@ class CachedRelationKernel::Impl {
     for (auto field : result_schema_->fields()) {
       std::shared_ptr<RelationColumn> col_out;
       RETURN_NOT_OK(MakeRelationColumn(field->type()->id(), &col_out));
-      for (auto arr : cached_[idx]) {
-        RETURN_NOT_OK(col_out->AppendColumn(arr));
+      if (cached_.size() == col_num_) {
+        for (auto arr : cached_[idx]) {
+          RETURN_NOT_OK(col_out->AppendColumn(arr));
+        }
       }
       sort_relation_list.push_back(col_out);
       idx++;


### PR DESCRIPTION
When DPP enabled, AQE won't work to replace smj with BHJ, so in Q95, there is one smj whose both sides are smj.

To fix this issue, 
1. we add a new strategy to split two wscg when smj are connected by build side.
2. we also added a support to treat any operator as buildSide operator in smj.
3. fix a bug when buildSide input is empty.
4. Add a strategy that If only one side child is smj, then this side will be treated as streamedSide

Fixed: https://github.com/oap-project/native-sql-engine/issues/22