### PR TITLE
[NSE-29][DNM] support mutiple-key sort without codegen

### DIFF
--- a/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -27,6 +27,8 @@ case class ColumnarNumaBindingInfo(
 class ColumnarPluginConfig(conf: SparkConf) {
   val enableColumnarSort: Boolean =
     conf.getBoolean("spark.sql.columnar.sort", defaultValue = false)
+  val enableColumnarCodegenSort: Boolean =
+    conf.getBoolean("spark.sql.columnar.codegen.sort", defaultValue = true)
   val enableColumnarNaNCheck: Boolean =
     conf.getBoolean("spark.sql.columnar.nanCheck", defaultValue = false)
   val enableCodegenHashAggregate: Boolean =

--- a/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -231,6 +231,7 @@ object ColumnarSorter extends Logging {
       result_type: Int = 0): TreeNode = {
     logInfo(s"ColumnarSorter sortOrder is ${sortOrder}, outputAttributes is ${outputAttributes}")
     val NaNCheck = ColumnarPluginConfig.getConf(sparkConf).enableColumnarNaNCheck
+    val codegen = ColumnarPluginConfig.getConf(sparkConf).enableColumnarCodegenSort
     /////////////// Prepare ColumnarSorter //////////////
     val outputFieldList: List[Field] = outputAttributes.toList.map(expr => {
       val attr = ConverterUtils.getAttrFromExpr(expr)
@@ -320,6 +321,11 @@ object ColumnarSorter extends Logging {
         TreeBuilder.makeLiteral(NaNCheck.asInstanceOf[java.lang.Boolean])),
       new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
 
+    val codegen_node = TreeBuilder.makeFunction(
+      "codegen",
+      Lists.newArrayList(TreeBuilder.makeLiteral(codegen.asInstanceOf[java.lang.Boolean])),
+      new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
+
     val result_type_node = TreeBuilder.makeFunction(
       "result_type",
       Lists.newArrayList(TreeBuilder.makeLiteral(result_type.asInstanceOf[Integer])),
@@ -335,6 +341,7 @@ object ColumnarSorter extends Logging {
           dir_node,
           nulls_order_node,
           NaN_check_node,
+          codegen_node,
           result_type_node),
       new ArrowType.Int(32, true) /*dummy ret type, won't be used*/ )
 

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_BUILD_TYPE  "Debug")
+set(CMAKE_BUILD_TYPE  "Release")
 
 option(USE_AVX512 "Build with AVX-512 optimizations" OFF)
 option(TESTS "Build the tests" OFF)

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_BUILD_TYPE  "Release")
+set(CMAKE_BUILD_TYPE  "Debug")
 
 option(USE_AVX512 "Build with AVX-512 optimizations" OFF)
 option(TESTS "Build the tests" OFF)

--- a/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
+++ b/cpp/src/codegen/arrow_compute/ext/kernels_ext.h
@@ -319,14 +319,19 @@ class SortArraysToIndicesKernel : public KernalBase {
                             gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::vector<bool> sort_directions,
-                            std::vector<bool> nulls_order, bool NaN_check,
-                            int result_type, std::shared_ptr<KernalBase>* out);
+                            std::vector<bool> nulls_order, 
+                            bool NaN_check,
+                            bool do_codegen,
+                            int result_type,
+                            std::shared_ptr<KernalBase>* out);
   SortArraysToIndicesKernel(arrow::compute::FunctionContext* ctx,
                             std::shared_ptr<arrow::Schema> result_schema,
                             gandiva::NodeVector sort_key_node,
                             std::vector<std::shared_ptr<arrow::Field>> key_field_list,
                             std::vector<bool> sort_directions,
-                            std::vector<bool> nulls_order, bool NaN_check,
+                            std::vector<bool> nulls_order, 
+                            bool NaN_check,
+                            bool do_codegen,
                             int result_type);
   arrow::Status Evaluate(const ArrayList& in) override;
   arrow::Status MakeResultIterator(

--- a/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/cpp/src/tests/arrow_compute_test_sort.cc
@@ -60,7 +60,9 @@ TEST(TestArrowComputeSort, SortTestInPlaceNullsFirstAsc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, 
+        &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -143,7 +145,8 @@ TEST(TestArrowComputeSort, SortTestInplaceNullsLastAsc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -226,7 +229,9 @@ TEST(TestArrowComputeSort, SortTestInplaceNullsFirstDesc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, 
+        &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -309,7 +314,9 @@ TEST(TestArrowComputeSort, SortTestInplaceNullsLastDesc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, 
+        &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -392,7 +399,9 @@ TEST(TestArrowComputeSort, SortTestInplaceAsc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, 
+        &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -475,8 +484,9 @@ TEST(TestArrowComputeSort, SortTestInplaceDesc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, 
+                                    &sort_expr, true));
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
@@ -557,8 +567,9 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAsc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
-
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
@@ -647,7 +658,8 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsLastAsc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -735,7 +747,8 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstDesc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -823,7 +836,8 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsLastDesc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -914,7 +928,8 @@ TEST(TestArrowComputeSort, SortTestOnekeyBooleanDesc) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -1007,7 +1022,8 @@ TEST(TestArrowComputeSort, SortTestOneKeyStr) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
@@ -1093,7 +1109,8 @@ TEST(TestArrowComputeSort, SortTestOneKeyWithProjection) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
-  ASSERT_NOT_OK(CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
   std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
@@ -1179,8 +1196,9 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysNaN) {
   std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
+  arrow::compute::FunctionContext ctx;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+      CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -1315,8 +1333,9 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
   auto ret_schema = arrow::schema(ret_types);
   ///////////////////// Calculation //////////////////
   std::shared_ptr<CodeGenerator> sort_expr;
+  arrow::compute::FunctionContext ctx;
   ASSERT_NOT_OK(
-      CreateCodeGenerator(sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+      CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
 
   std::shared_ptr<arrow::RecordBatch> input_batch;
   std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
@@ -1388,6 +1407,224 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
   }
 }
 
+TEST(TestArrowComputeSort, SortTestMultipleKeysUnsafeRow) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", uint32());
+  auto f2 = field("f2", uint32());
+  auto f3 = field("f3", float32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0, arg_1, arg_2}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0, arg_1, arg_2}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal, false_literal, true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {false_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[8, null, 4, null, 52, 32, 11]",
+                                                "[4, 2, 4, 7, 8, 0, 10]",
+                                                "[11, 2, 5, 51, 8, 33, 12]",
+                                                "[1, 3, 5, 10, 9, 13, 2]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_2 = {"[1, 14, 1, null, 6, 1, 2]",
+                                                  "[10, 12, null, 9, 2, 10, 13]",
+                                                  "[2, 5, 44, 43, 7, 34, 3]",
+                                                  "[9, 7, 5, 1, 5, 8, 17]"};
+  MakeInputBatch(input_data_string_2, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 1]",
+                                                  "[32, 12, 14, 27, 18, 10, null]",
+                                                  "[4, 65, 16, 8, 10, 20, 34]",
+                                                  "[8, 6, 2, 3, 10, 12, 15]"};
+  MakeInputBatch(input_data_string_3, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                  "[14, 12, 24, 17, 18, 19, 7]",
+                                                  "[24, 18, 42, 4, 21, 36, 31]",
+                                                  "[15, 16, 2, 51, 3, 33, 12]"};
+  MakeInputBatch(input_data_string_4, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  std::vector<std::string> input_data_string_5 = {"[37, 8, 22, 13, 8, 59, 21]",
+                                                  "[12, 10, 14, 18, 2, 0, 11]",
+                                                  "[38, 67, 23, 14, 9, 60, 22]",
+                                                  "[16, 17, 5, 15, 9, 1, 19]"};
+  MakeInputBatch(input_data_string_5, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 35, 37, 41, 42, 50, 52, 59, 64, 2, 3, 5, null, null]",
+      "[2, 3, 4, 5, 7, 8, 11, null, 16, 20, 10, 12, 14, null, 18, 6, 21, 22, 23, "
+      "24, 31, 33, 36, 38, 42, 43, 51, null, 60, 65, 44, 34, 2, 67, 34]",
+      "[2, 3, 4, 5, 7, 8, 11, null, 16, 20, 10, 12, 14, null, 18, 4, 21, 22, 23, "
+      "24, 31, 33, 36, 38, 42, 43, 51, null, 60, 65, 44, 34, 8, 67, 34]",
+      "[9, 17, 8, 5, 5, 3, 1, 9, 2, 12, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 33, 16, 2, 1, 10, null, null, 6, 5, 15, 3, 17, null]"};
+
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
+TEST(TestArrowComputeSort, SortTestMultipleKeysUnsafeStr) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", float64());
+  auto f1 = field("f1", utf8());
+  auto f2 = field("f2", float64());
+  auto f3 = field("f3", float64());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  auto f_res = field("res", uint32());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {arg_0, arg_1, arg_2}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0, arg_1, arg_2}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal, false_literal, true_literal}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[8, 1, 4, 50, 52, 32, 11]",
+                                                R"([null, "a", "a", "b", "b","b", "b"])",
+                                                "[11, 2, 5, 51, 8, 33, 12]",
+                                                "[1, 3, 5, 10, 12, 13, 2]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+   std::vector<std::string> input_data_string_2 = {"[1, 14, 2, 42, 6, 5, 2]",
+                                                   R"(["a", "a", "c", "b", "b", "a", "b"])",
+                                                   "[2, 8, 44, 43, 7, 34, 3]",
+                                                   "[9, 7, 5, 1, 5, 9, 17]"};
+   MakeInputBatch(input_data_string_2, sch, &input_batch);
+   input_batch_list.push_back(input_batch);
+
+   std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 12]",
+                                                   R"(["a", "a", null, "b", "b","b", "b"])",
+                                                   "[4, 65, 16, 8, 10, 20, 34]",
+                                                   "[8, 6, 2, 3, 10, 12, 15]"};
+    MakeInputBatch(input_data_string_3, sch, &input_batch);
+    input_batch_list.push_back(input_batch);
+
+   std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
+                                                   "[24, 18, 42, 12, 21, 36, 31]",
+                                                   "[15, 16, 2, 51, 8, 33, 12]"};
+   MakeInputBatch(input_data_string_4, sch, &input_batch);
+   input_batch_list.push_back(input_batch);
+
+   std::vector<std::string> input_data_string_5 = {"[37, 9, 22, 13, 8, 59, 21]",
+                                                   R"(["a", "b", "a", "b", "b","b", "b"])",
+                                                   "[38, 67, 23, 14, 15, 60, 22]",
+                                                   "[16, 17, 5, 15, 9, 6, 19]"};
+   MakeInputBatch(input_data_string_5, sch, &input_batch);
+   input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 35, 37, 41, 42, 50, 52, 59, 64, NaN, NaN, NaN, null, null]",
+      R"(["a","b","a","a","b","b", null,"b","b","b","b","b","b","a","a","b","b","b","a","a","b","b","b","a","a","b","b","b","b","a",null,"b","a","b","a"])",
+      "[2, 3, 4, 5, 7, 8, 11, null, 16, 20, 10, 12, 14, null, 18, NaN, 21, 22, 23, "
+      "24, 31, 33, 36, 38, 42, 43, 51, null, 60, 65, 44, 34, NaN, 67, 34]",
+      "[9, 17, 8, 5, 5, 3, 1, 9, 2, 12, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 33, 16, 2, 1, 10, null, null, 6, 5, 15, 3, 17, null]"};
+
+  MakeInputBatch(expected_result_string, sch, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
 
 }  // namespace codegen
 }  // namespace sparkcolumnarplugin

--- a/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/cpp/src/tests/arrow_compute_test_sort.cc
@@ -1676,5 +1676,145 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysUnsafeStr) {
   }
 }
 
+TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjectionWithoutCodegen) {
+  ////////////////////// prepare expr_vector ///////////////////////
+  auto f0 = field("f0", uint32());
+  auto f1 = field("f1", utf8());
+  auto f2 = field("f2", uint32());
+  auto f3 = field("f3", uint32());
+  auto arg_0 = TreeExprBuilder::MakeField(f0);
+  auto arg_1 = TreeExprBuilder::MakeField(f1);
+  auto arg_2 = TreeExprBuilder::MakeField(f2);
+  auto true_literal = TreeExprBuilder::MakeLiteral(true);
+  auto false_literal = TreeExprBuilder::MakeLiteral(false);
+  auto f_res = field("res", uint32());
+  auto f_bool = field("res", arrow::boolean());
+  auto indices_type = std::make_shared<FixedSizeBinaryType>(16);
+  auto f_indices = field("indices", indices_type);
+
+  auto uint32_node = TreeExprBuilder::MakeLiteral((uint32_t)0);
+  auto str_node = TreeExprBuilder::MakeStringLiteral("");
+
+  auto isnotnull_0 = TreeExprBuilder::MakeFunction(
+      "isnotnull", {TreeExprBuilder::MakeField(f0)}, arrow::boolean());
+  auto coalesce_0 = TreeExprBuilder::MakeIf(
+      isnotnull_0, TreeExprBuilder::MakeField(f0), uint32_node, uint32());
+  auto isnull_0 = TreeExprBuilder::MakeFunction(
+      "isnull", {arg_0}, arrow::boolean());
+
+  auto isnotnull_1 = TreeExprBuilder::MakeFunction(
+      "isnotnull", {TreeExprBuilder::MakeField(f1)}, arrow::boolean());
+  auto coalesce_1 = TreeExprBuilder::MakeIf(
+      isnotnull_1, TreeExprBuilder::MakeField(f1), str_node, utf8());
+  auto isnull_1 = TreeExprBuilder::MakeFunction(
+      "isnull", {arg_1}, arrow::boolean());
+  
+  auto isnotnull_2 = TreeExprBuilder::MakeFunction(
+      "isnotnull", {TreeExprBuilder::MakeField(f2)}, arrow::boolean());
+  auto coalesce_2 = TreeExprBuilder::MakeIf(
+      isnotnull_2, TreeExprBuilder::MakeField(f2), uint32_node, uint32());
+  auto isnull_2 = TreeExprBuilder::MakeFunction(
+      "isnull", {arg_2}, arrow::boolean());
+
+  auto n_key_func = TreeExprBuilder::MakeFunction(
+      "key_function", {coalesce_0, isnull_0, coalesce_1, isnull_1, coalesce_2, isnull_2}, uint32());
+  auto n_key_field = TreeExprBuilder::MakeFunction(
+      "key_field", {arg_0, arg_0, arg_1, arg_1, arg_2, arg_2}, uint32());
+  auto n_dir = TreeExprBuilder::MakeFunction(
+      "sort_directions", {true_literal, true_literal, false_literal, false_literal, 
+                          true_literal, true_literal,}, uint32());
+  auto n_nulls_order = TreeExprBuilder::MakeFunction(
+      "sort_nulls_order", {false_literal, false_literal, true_literal, true_literal, 
+                           true_literal, true_literal}, uint32());
+  auto NaN_check = TreeExprBuilder::MakeFunction(
+      "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
+  auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
+  auto n_sort = TreeExprBuilder::MakeFunction(
+      "standalone", {n_sort_to_indices}, uint32());
+  auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
+
+  auto sch = arrow::schema({f0, f1, f2, f3});
+  std::vector<std::shared_ptr<Field>> ret_types = {f0, f1, f2, f3};
+  auto ret_schema = arrow::schema(ret_types);
+  ///////////////////// Calculation //////////////////
+  std::shared_ptr<CodeGenerator> sort_expr;
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(
+      CreateCodeGenerator(ctx.memory_pool(), sch, {sortArrays_expr}, ret_types, &sort_expr, true));
+
+  std::shared_ptr<arrow::RecordBatch> input_batch;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> input_batch_list;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> dummy_result_batches;
+
+  std::vector<std::string> input_data_string = {"[8, 8, 4, 50, 52, 32, 11]",
+                                                R"([null, "b", "a", "b", "b","b", "b"])",
+                                                "[11, 10, 5, 51, null, 33, 12]",
+                                                "[1, 3, 5, 10, null, 13, 2]"};
+  MakeInputBatch(input_data_string, sch, &input_batch);
+  input_batch_list.push_back(input_batch);
+
+//   std::vector<std::string> input_data_string_2 = {"[1, 14, 8, 42, 6, null, 2]",
+//                                                   R"(["a", "a", null, "b", "b","b", "b"])",
+//                                                   "[2, null, 44, 43, 7, 34, 3]",
+//                                                   "[9, 7, 5, 1, 5, null, 17]"};
+//   MakeInputBatch(input_data_string_2, sch, &input_batch);
+//   input_batch_list.push_back(input_batch);
+
+//   std::vector<std::string> input_data_string_3 = {"[3, 64, 8, 7, 9, 8, 33]",
+//                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
+//                                                   "[4, 65, 16, 8, 10, 20, 34]",
+//                                                   "[8, 6, 2, 3, 10, 12, 15]"};
+//   MakeInputBatch(input_data_string_3, sch, &input_batch);
+//   input_batch_list.push_back(input_batch);
+
+//   std::vector<std::string> input_data_string_4 = {"[23, 17, 41, 18, 20, 35, 30]",
+//                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
+//                                                   "[24, 18, 42, 19, 21, 36, 31]",
+//                                                   "[15, 16, 2, 51, null, 33, 12]"};
+//   MakeInputBatch(input_data_string_4, sch, &input_batch);
+//   input_batch_list.push_back(input_batch);
+
+//   std::vector<std::string> input_data_string_5 = {"[37, null, 22, 13, 8, 59, 21]",
+//                                                   R"(["a", "a", "a", "b", "b","b", "b"])",
+//                                                   "[38, 67, 23, 14, null, 60, 22]",
+//                                                   "[16, 17, 5, 15, 9, null, 19]"};
+//   MakeInputBatch(input_data_string_5, sch, &input_batch);
+//   input_batch_list.push_back(input_batch);
+
+  ////////////////////////////////// calculation ///////////////////////////////////
+  std::shared_ptr<arrow::RecordBatch> expected_result;
+  std::vector<std::string> expected_result_string = {
+      "[null, null, 1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 8, 8, 9, 11, 13, 14, 17, 18, 20, 21, "
+      "22, 23, 30, 32, 33, 35, 37, 41, 42, 50, 52, 59, 64]",
+      R"(["b","a","a","b","a","a","b","b","b","b","b","a", null, null,"b","b","b","a","a","b","b","b","a","a","b","b","b","b","a","a","b","b","b","b","a"])",
+      "[34, 67, 2, 3, 4, 5, 7, 8, null, 10, 20, 16, 11, 44, 10, 12, 14, null, 18, 19, 21, 22, 23, "
+      "24, 31, 33, 34, 36, 38, 42, 43, 51, null, 60, 65]",
+      "[null, 17, 9, 17, 8, 5, 5, 3, 9, 3, 12, 2, 1, 5, 10, 2, 15, 7, 16, 51, null, 19, 5, "
+      "15, 12, 13, 15, 33, 16, 2, 1, 10, null, null, 6]"};
+
+  MakeInputBatch(expected_result_string, ret_schema, &expected_result);
+
+  for (auto batch : input_batch_list) {
+    ASSERT_NOT_OK(sort_expr->evaluate(batch, &dummy_result_batches));
+  }
+  std::shared_ptr<ResultIterator<arrow::RecordBatch>> sort_result_iterator;
+  std::shared_ptr<ResultIteratorBase> sort_result_iterator_base;
+  ASSERT_NOT_OK(sort_expr->finish(&sort_result_iterator_base));
+  sort_result_iterator = std::dynamic_pointer_cast<ResultIterator<arrow::RecordBatch>>(
+      sort_result_iterator_base);
+
+  std::shared_ptr<arrow::RecordBatch> dummy_result_batch;
+  std::shared_ptr<arrow::RecordBatch> result_batch;
+
+  if (sort_result_iterator->HasNext()) {
+    ASSERT_NOT_OK(sort_result_iterator->Next(&result_batch));
+    ASSERT_NOT_OK(Equals(*expected_result.get(), *result_batch.get()));
+  }
+}
+
 }  // namespace codegen
 }  // namespace sparkcolumnarplugin

--- a/cpp/src/tests/arrow_compute_test_sort.cc
+++ b/cpp/src/tests/arrow_compute_test_sort.cc
@@ -50,8 +50,11 @@ TEST(TestArrowComputeSort, SortTestInPlaceNullsFirstAsc) {
       "sort_nulls_order", {true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());    
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -135,8 +138,11 @@ TEST(TestArrowComputeSort, SortTestInplaceNullsLastAsc) {
       "sort_nulls_order", {false_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -219,8 +225,11 @@ TEST(TestArrowComputeSort, SortTestInplaceNullsFirstDesc) {
       "sort_nulls_order", {true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -304,8 +313,11 @@ TEST(TestArrowComputeSort, SortTestInplaceNullsLastDesc) {
       "sort_nulls_order", {false_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -389,8 +401,11 @@ TEST(TestArrowComputeSort, SortTestInplaceAsc) {
       "sort_nulls_order", {false_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -474,8 +489,11 @@ TEST(TestArrowComputeSort, SortTestInplaceDesc) {
       "sort_nulls_order", {false_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -557,8 +575,11 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstAsc) {
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -648,8 +669,11 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsLastAsc) {
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {TreeExprBuilder::MakeLiteral(false)}, uint32());    
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -737,6 +761,8 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsFirstDesc) {
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(true)}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
       "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
@@ -826,8 +852,11 @@ TEST(TestArrowComputeSort, SortTestOnekeyNullsLastDesc) {
       "sort_nulls_order", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {TreeExprBuilder::MakeLiteral(true)}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {TreeExprBuilder::MakeLiteral(false)}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -918,8 +947,11 @@ TEST(TestArrowComputeSort, SortTestOnekeyBooleanDesc) {
       "sort_nulls_order", {true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -1012,8 +1044,11 @@ TEST(TestArrowComputeSort, SortTestOneKeyStr) {
       "sort_nulls_order", {false_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -1099,8 +1134,11 @@ TEST(TestArrowComputeSort, SortTestOneKeyWithProjection) {
       "sort_nulls_order", {false_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -1186,8 +1224,11 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysNaN) {
       "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -1322,8 +1363,11 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysWithProjection) {
                            true_literal, true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {true_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -1432,8 +1476,11 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysUnsafeRow) {
       "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {false_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);
@@ -1542,8 +1589,11 @@ TEST(TestArrowComputeSort, SortTestMultipleKeysUnsafeStr) {
       "sort_nulls_order", {false_literal, true_literal, true_literal}, uint32());
   auto NaN_check = TreeExprBuilder::MakeFunction(
       "NaN_check", {true_literal}, uint32());
+  auto do_codegen = TreeExprBuilder::MakeFunction(
+      "codegen", {false_literal}, uint32());
   auto n_sort_to_indices = TreeExprBuilder::MakeFunction(
-      "sortArraysToIndices", {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check}, uint32());
+      "sortArraysToIndices", 
+      {n_key_func, n_key_field, n_dir, n_nulls_order, NaN_check, do_codegen}, uint32());
   auto n_sort = TreeExprBuilder::MakeFunction(
       "standalone", {n_sort_to_indices}, uint32());
   auto sortArrays_expr = TreeExprBuilder::MakeExpression(n_sort, f_res);

--- a/cpp/src/third_party/row_wise_memory/accessible_unsafe_row.h
+++ b/cpp/src/third_party/row_wise_memory/accessible_unsafe_row.h
@@ -150,8 +150,14 @@ struct AccessibleUnsafeRow {
       auto left = *((char*)(data + left_offset));
       int right_offset = *((int*)(row_to_compare->getData() + str_offset_cursor));
       auto right = *((char*)(row_to_compare->getData() + right_offset));
+      std::cout << "string left is: " << left << "right is: " << right << std::endl;
       return compareInternal<char>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::BOOL) {
+      auto left = *((bool*)(data + offset));
+      auto right = *((bool*)(row_to_compare->getData() + offset));
+      return compareInternal<bool>(left, right, asc, nulls_first);
     }
+    std::cout << "Unsupported type: " << field->type() << std::endl;
     return -1;
   }
 };
@@ -243,6 +249,7 @@ class RowComparator {
       bool nulls_first = nulls_order_[key_idx];
       int comparison = unsafe_rows_[left_array_id][left_id]->compare(
           unsafe_rows_[right_array_id][right_id], key_idx, asc, nulls_first);
+      std::cout << "comparison: " << comparison << std::endl;
       if (comparison != 2) {
         return comparison;
       }

--- a/cpp/src/third_party/row_wise_memory/accessible_unsafe_row.h
+++ b/cpp/src/third_party/row_wise_memory/accessible_unsafe_row.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include <arrow/util/decimal.h>
+#include <assert.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <string>
+
+#include "third_party/row_wise_memory/native_memory.h"
+#include <vector>
+#include <arrow/type.h>
+
+#define TEMP_ACCESSIBLE_UNSAFEROW_BUFFER_SIZE 1024
+#define FIXED_UNSAFEROW_NUMERIC_SIZE 8
+
+/* Accessible Unsafe Row Layout
+ * (This accessible unsafe row is used to append all fields data as easy-to-access memory)
+ *
+ * | validity | col 0 | col 1 | col 2 | ...
+ * explain:
+ * validity: n fields = (n/8 + 1) bytes
+ * col: each col has variable size
+ * cursor: used to pointer to cur unused pos
+ *
+ */
+struct AccessibleUnsafeRow {
+  int numFields_;
+  char* data = nullptr;
+  int validity_size_;
+  int cursor_ = 0;
+  int str_cursor_ = 0;
+  std::vector<std::shared_ptr<arrow::Field>> col_field_list_;
+
+  AccessibleUnsafeRow() {}
+  AccessibleUnsafeRow(std::vector<std::shared_ptr<arrow::Field>> col_field_list)
+      : numFields_(col_field_list.size()),
+        col_field_list_(col_field_list) {
+    validity_size_ = (numFields_ / 8) + 1;
+    str_cursor_ = col_field_list.size() * FIXED_UNSAFEROW_NUMERIC_SIZE;
+    data = (char*)nativeMalloc(TEMP_ACCESSIBLE_UNSAFEROW_BUFFER_SIZE, MEMTYPE_ROW);
+    memset(data, 0, validity_size_);
+  }
+  ~AccessibleUnsafeRow() {
+    if (data) {
+      nativeFree(data);
+    }
+  }
+  int sizeInBytes() { return validity_size_ + str_cursor_; }
+  void reset() {
+    memset(data, 0, validity_size_ + str_cursor_);
+    cursor_ = 0;
+    str_cursor_ = 0;
+  }
+  bool isNullExists() {
+    for (int i = 0; i < ((numFields_ / 8) + 1); i++) {
+      if (data[i] != 0) return true;
+    }
+    return false;
+  }
+  bool isNullAt(int index) {
+    assert((index >= 0) && (index < numFields_));
+    auto bitSetIdx = index >> 3;  // mod 8
+    bool is_null = (*(data + bitSetIdx) & kBitmask[index % 8]) != 0;
+    return is_null;
+  }
+  auto getData() {
+    return data;
+  }
+  template <typename T>
+  int compareInternal(T left, T right, bool asc, bool nulls_first) {
+    int comparison;
+    if (left == right) {
+      comparison = 2;
+    } else {
+      if (asc) {
+        comparison = left < right;
+      } else {
+        comparison = left > right;
+      }
+    }
+    return comparison;
+  }
+  int compare(std::shared_ptr<AccessibleUnsafeRow> row_to_compare, int key_idx, 
+      bool asc, bool nulls_first) {
+    auto field = col_field_list_[key_idx];
+    bool is_left_null = isNullAt(key_idx);
+    bool is_right_null = row_to_compare->isNullAt(key_idx);
+    if (is_left_null && is_right_null) {
+      return 2;
+    } else if (is_left_null) {
+      return nulls_first ? 1 : 0;
+    } else if (is_right_null) {
+      return nulls_first ? 0 : 1;
+    }
+    int offset = validity_size_ + key_idx * FIXED_UNSAFEROW_NUMERIC_SIZE;
+    if (field->type()->id() == arrow::Type::UINT8) {
+      auto left = *((uint8_t*)(data + offset));
+      auto right = *((uint8_t*)(row_to_compare->getData() + offset));
+      return compareInternal<uint8_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::INT8) {
+      auto left = *((int8_t*)(data + offset));
+      auto right = *((int8_t*)(row_to_compare->getData() + offset));
+      return compareInternal<int8_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::UINT16) {
+      auto left = *((uint16_t*)(data + offset));
+      auto right = *((uint16_t*)(row_to_compare->getData() + offset));
+      return compareInternal<uint16_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::INT16) {
+      auto left = *((int16_t*)(data + offset));
+      auto right = *((int16_t*)(row_to_compare->getData() + offset));
+      return compareInternal<int16_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::UINT32) {
+      auto left = *((uint32_t*)(data + offset));
+      auto right = *((uint32_t*)(row_to_compare->getData() + offset));
+      return compareInternal<uint32_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::INT32) {
+      auto left = *((int*)(data + offset));
+      auto right = *((int*)(row_to_compare->getData() + offset));
+      return compareInternal<int>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::UINT64) {
+      auto left = *((uint64_t*)(data + offset));
+      auto right = *((uint64_t*)(row_to_compare->getData() + offset));
+      return compareInternal<uint64_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::INT64) {
+      auto left = *((int64_t*)(data + offset));
+      auto right = *((int64_t*)(row_to_compare->getData() + offset));
+      return compareInternal<int64_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::DATE32) {
+      auto left = *((int*)(data + offset));
+      auto right = *((int*)(row_to_compare->getData() + offset));
+      return compareInternal<int>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::DATE64) {
+      auto left = *((int64_t*)(data + offset));
+      auto right = *((int64_t*)(row_to_compare->getData() + offset));
+      return compareInternal<int64_t>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::DOUBLE) {
+      auto left = *((double*)(data + offset));
+      auto right = *((double*)(row_to_compare->getData() + offset));
+      return compareInternal<double>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::FLOAT) {
+      auto left = *((float*)(data + offset));
+      auto right = *((float*)(row_to_compare->getData() + offset));
+      return compareInternal<float>(left, right, asc, nulls_first);
+    } else if (field->type()->id() == arrow::Type::STRING) {
+      int str_offset_cursor = validity_size_ + key_idx * FIXED_UNSAFEROW_NUMERIC_SIZE + 
+          FIXED_UNSAFEROW_NUMERIC_SIZE / 2;
+      int left_offset = *((int*)(data + str_offset_cursor));
+      auto left = *((char*)(data + left_offset));
+      int right_offset = *((int*)(row_to_compare->getData() + str_offset_cursor));
+      auto right = *((char*)(row_to_compare->getData() + right_offset));
+      return compareInternal<char>(left, right, asc, nulls_first);
+    }
+    return -1;
+  }
+};
+
+static inline int calculateBitSetWidthInBytesAccessible(int numFields) {
+  return ((numFields / 8) + 1);
+}
+
+static inline int getSizeInBytesAccessible(AccessibleUnsafeRow* row) { 
+  return row->validity_size_ + row->str_cursor_;
+}
+
+static inline int roundNumberOfBytesToNearestWordAccessible(int numBytes) {
+  int remainder = numBytes & 0x07;  // This is equivalent to `numBytes % 8`
+  if (remainder == 0) {
+    return numBytes;
+  } else {
+    return numBytes + (8 - remainder);
+  }
+}
+
+static inline void zeroOutPaddingBytesAccessible(AccessibleUnsafeRow* row, int numBytes) {
+  if ((numBytes & 0x07) > 0) {
+    *((int64_t*)(char*)(row->data + row->validity_size_ + row->str_cursor_ + 
+                ((numBytes >> 3) << 3))) = 0L;
+  }
+}
+
+static inline void setNullAtAccessible(AccessibleUnsafeRow* row, int index) {
+  assert((index >= 0) && (index < row->numFields_));
+  auto bitSetIdx = index >> 3;  // mod 8
+  *(row->data + bitSetIdx) |= kBitmask[index % 8];
+}
+
+template <typename T>
+using is_number_alike = std::integral_constant<bool, std::is_arithmetic<T>::value ||
+                                               std::is_floating_point<T>::value>;
+
+template <typename T, typename std::enable_if_t<is_number_alike<T>::value>* = nullptr>
+static inline void appendToAccessibleUnsafeRow(
+    AccessibleUnsafeRow* row, const int& index, const T& val) {
+  *((T*)(row->data + row->validity_size_ + row->cursor_)) = val;
+  row->cursor_ += FIXED_UNSAFEROW_NUMERIC_SIZE;
+}
+
+static inline void appendToAccessibleUnsafeRow(
+    AccessibleUnsafeRow* row, const int& index, const std::string& str) {
+  int numBytes = str.size();
+  // int roundedSize = roundNumberOfBytesToNearestWord(numBytes);
+
+  // zeroOutPaddingBytes(row, numBytes);
+  *((int*)(row->data + row->validity_size_ + row->cursor_)) = numBytes;
+  int offset = row->str_cursor_;
+  *((int*)(row->data + row->validity_size_ + row->cursor_ + 
+      FIXED_UNSAFEROW_NUMERIC_SIZE / 2)) = offset;
+  memcpy(row->data + row->validity_size_ + row->str_cursor_, 
+         str.c_str(), numBytes);
+  // move the cursor forward.
+  row->cursor_ += FIXED_UNSAFEROW_NUMERIC_SIZE;
+  row->str_cursor_ += numBytes;
+}
+
+// static inline void appendToUnsafeRow(AccessibleUnsafeRow* row, const int& index,
+//                                      const arrow::Decimal128& dcm) {
+//   int numBytes = 16;
+//   zeroOutPaddingBytes(row, numBytes);
+//   memcpy(row->data + row->cursor, dcm.ToBytes().data(), numBytes);
+//   // move the cursor forward.
+//   row->cursor += numBytes;
+// }
+
+class RowComparator {
+ public:
+  RowComparator(
+      std::vector<std::vector<std::shared_ptr<AccessibleUnsafeRow>>>& unsafe_rows, 
+      std::vector<bool> sort_directions, 
+      std::vector<bool> nulls_order) 
+      : unsafe_rows_(unsafe_rows),
+        sort_directions_(sort_directions),
+        nulls_order_(nulls_order) {
+      }
+
+  int compareInternal(int left_array_id, int64_t left_id, 
+                      int right_array_id, int64_t right_id) {
+    int key_idx = 0;
+    int keys_num = sort_directions_.size();
+    while (key_idx < keys_num) {
+      bool asc = sort_directions_[key_idx];
+      bool nulls_first = nulls_order_[key_idx];
+      int comparison = unsafe_rows_[left_array_id][left_id]->compare(
+          unsafe_rows_[right_array_id][right_id], key_idx, asc, nulls_first);
+      if (comparison != 2) {
+        return comparison;
+      }
+      key_idx += 1;
+    }
+    return 2;
+  }
+
+  bool compare(int left_array_id, int64_t left_len, 
+               int right_array_id, int64_t right_len) {
+    if (compareInternal(left_array_id, left_len, right_array_id, right_len) == 1) {
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  std::vector<std::vector<std::shared_ptr<AccessibleUnsafeRow>>> unsafe_rows_;
+  std::vector<bool> sort_directions_;
+  std::vector<bool> nulls_order_;
+};


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr supports a non-codegen version of mutiple-key sort.
fixes https://github.com/oap-project/native-sql-engine/issues/29


## How was this patch tested?

under performance test

