### PR TITLE
[NSE-40] fixes driver failing to do sort codege

### DIFF
--- a/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
+++ b/core/src/main/scala/com/intel/oap/execution/ColumnarSortExec.scala
@@ -135,10 +135,10 @@ case class ColumnarSortExec(
 
   /***********************************************************/
   def getCodeGenSignature =
-    if (!sortOrder
-          .filter(
-            expr => bindReference(expr.child, child.output, true).isInstanceOf[BoundReference])
-          .isEmpty) {
+    if (sortOrder.exists(expr =>
+        bindReference(
+          ConverterUtils.getAttrFromExpr(expr.child), child.output, true)
+          .isInstanceOf[BoundReference])) {
       ColumnarSorter.prebuild(
         sortOrder,
         child.output,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fixes driver failing to do sort codege, due to signature is empty.
The reason is filter not working for sortOrder containing projection exprs.
fixes https://github.com/oap-project/native-sql-engine/issues/40


## How was this patch tested?

under test

