### PR TITLE
[NSE-42] early release sort input

### DIFF
--- a/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -92,7 +92,6 @@ class ColumnarSorter(
     elapse.set(NANOSECONDS.toMillis(total_elapse))
     sortTime.set(NANOSECONDS.toMillis(sort_elapse))
     shuffleTime.set(NANOSECONDS.toMillis(shuffle_elapse))
-    inputBatchHolder.foreach(cb => cb.close())
     if (sorter != null) {
       sorter.close()
     }

--- a/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -153,7 +153,12 @@ class ColumnarSorter(
           sort_elapse += System.nanoTime() - beforeSort
           total_elapse += System.nanoTime() - beforeSort
         }
-        sort_iterator.hasNext()
+        if (sort_iterator.hasNext()) {
+          return true
+        } else {
+          inputBatchHolder.foreach(cb => cb.close())
+          return false
+        }
       }
 
       override def next(): ColumnarBatch = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

partially fixes: #42 

this patch tries to close sort input when there's no next result in sort result iterator. In cases like columnar WSCG, this can help to release the memory on the first consumer operator of columnar sort, instead of waiting for the last operator to release all batches. 

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?
verified locally
