### PR TITLE
[NSE-45] BHJ memory leak

### DIFF
--- a/.github/workflows/report_ram_log.yml
+++ b/.github/workflows/report_ram_log.yml
@@ -59,7 +59,8 @@ jobs:
           git clone https://github.com/oap-project/arrow-data-source.git
           cd arrow-data-source
           mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests
-      - run: |
+      - name: Run Maven tests
+        run: |
           cd core/
           mvn test -B -DmembersOnlySuites=com.intel.oap.tpch -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DtagsToInclude=com.intel.oap.tags.CommentOnContextPR -Dexec.skip=true
         env:

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -37,7 +37,6 @@ jobs:
       - run: free
       - run: sudo apt-get install cmake
       - run: sudo apt-get install libboost-all-dev
-      - run: sudo apt-get install libjemalloc-dev
       - name: Install OAP optimized Arrow
         run: |
           cd /tmp
@@ -59,7 +58,7 @@ jobs:
           cd core/
           mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs
         env:
-          LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+          MALLOC_ARENA_MAX: "4"
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"
           COMMENT_IMAGE_OUTPUT_PATH: "/tmp/comment_image.png"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -38,7 +38,6 @@ jobs:
       - run: sudo apt-get install cmake
       - run: sudo apt-get install libboost-all-dev
       - run: sudo apt-get install libjemalloc-dev
-      - run: find / -name libjemalloc.so
       - name: Install OAP optimized Arrow
         run: |
           cd /tmp
@@ -60,7 +59,7 @@ jobs:
           cd core/
           mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs
         env:
-          LD_PRELOAD: "/tmp/arrow/cpp/build/jemalloc_ep-prefix/src/jemalloc_ep/lib/libjemalloc.so"
+          LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libjemalloc.so"
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"
           COMMENT_IMAGE_OUTPUT_PATH: "/tmp/comment_image.png"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -43,7 +43,7 @@ jobs:
           git clone https://github.com/intel-bigdata/arrow.git
           cd arrow && git checkout oap-master && cd cpp
           mkdir build && cd build
-          cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON && make -j2
+          cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DARROW_JEMALLOC=OFF && make -j2
           sudo make install
           cd ../../java
           mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -P arrow-jni -am -Darrow.cpp.build.dir=/tmp/arrow/cpp/build/release/ -DskipTests -Dcheckstyle.skip
@@ -53,10 +53,12 @@ jobs:
           git clone https://github.com/oap-project/arrow-data-source.git
           cd arrow-data-source
           mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-      - run: |
+      - name: Run Maven tests
+        run: |
           cd core/
           mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs
         env:
+          LD_PRELOAD: "/tmp/arrow/cpp/build/jemalloc_ep-prefix/src/jemalloc_ep/lib/libjemalloc.so"
           MAVEN_OPTS: "-Xmx2048m"
           COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"
           COMMENT_IMAGE_OUTPUT_PATH: "/tmp/comment_image.png"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Run Maven tests
         run: |
           cd core/
-          mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs
+          mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DmembersOnlySuites=com.intel.oap.tpch -DtagsToInclude=com.intel.oap.tags.TestAndWriteLogs -DargLine="-Xmx1G -XX:MaxDirectMemorySize=500M -Dio.netty.allocator.numDirectArena=1"
         env:
           MALLOC_ARENA_MAX: "4"
-          MAVEN_OPTS: "-Xmx2048m"
+          MAVEN_OPTS: "-Xmx1G"
           COMMENT_TEXT_OUTPUT_PATH: "/tmp/comment_text.txt"
           COMMENT_IMAGE_OUTPUT_PATH: "/tmp/comment_image.png"
           ENABLE_TPCH_TESTS: "true"

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -37,6 +37,8 @@ jobs:
       - run: free
       - run: sudo apt-get install cmake
       - run: sudo apt-get install libboost-all-dev
+      - run: sudo apt-get install libjemalloc-dev
+      - run: find / -name libjemalloc.so
       - name: Install OAP optimized Arrow
         run: |
           cd /tmp

--- a/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
+++ b/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
@@ -66,15 +66,12 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
   private int ordinal;
   private ValueVector vector;
   private ValueVector dictionaryVector;
-  private static BufferAllocator OffRecordAllocator = null;
+  private static BufferAllocator OffRecordAllocator = SparkMemoryUtils.globalAllocator();
 
   public static BufferAllocator getAllocator() {
     return SparkMemoryUtils.contextAllocator();
   }
   public static BufferAllocator getOffRecordAllocator() {
-    if (OffRecordAllocator == null) {
-      OffRecordAllocator = new RootAllocator(Long.MAX_VALUE);
-    }
     return OffRecordAllocator;
   }
   public static AtomicLong vectorCount = new AtomicLong(0);

--- a/core/src/main/java/com/intel/oap/vectorized/BatchIterator.java
+++ b/core/src/main/java/com/intel/oap/vectorized/BatchIterator.java
@@ -29,7 +29,7 @@ import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.ArrowBuffer;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 
-public class BatchIterator {
+public class BatchIterator implements AutoCloseable {
   private native boolean nativeHasNext(long nativeHandler);
   private native ArrowRecordBatchBuilder nativeNext(long nativeHandler);
   private native MetricsObject nativeFetchMetrics(long nativeHandler);
@@ -89,7 +89,7 @@ public class BatchIterator {
       return null;
     }
     NativeSerializableObject obj = nativeNextHashRelation(nativeHandler);
-    SerializableObject objImpl = new SerializableObject(obj);
+    SerializableObject objImpl = new SerializableObject(obj, new AutoCloseable[]{this});
     return objImpl;
   }
 
@@ -196,6 +196,7 @@ public class BatchIterator {
     nativeSetDependencies(nativeHandler, instanceIdList);
   }
 
+  @Override
   public void close() {
     if (!closed) {
       nativeClose(nativeHandler);

--- a/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
+++ b/core/src/main/scala/com/intel/oap/ColumnarPluginConfig.scala
@@ -54,7 +54,7 @@ class ColumnarPluginConfig(conf: SparkConf) {
     conf.getBoolean("spark.oap.sql.columnar.wholestagecodegen.breakdownTime", defaultValue = false)
   val tmpFile: String =
     conf.getOption("spark.sql.columnar.tmp_dir").getOrElse(null)
-  val broadcastCacheTimeout: Int =
+  @deprecated val broadcastCacheTimeout: Int =
     conf.getInt("spark.sql.columnar.sort.broadcast.cache.timeout", defaultValue = -1)
   val hashCompare: Boolean =
     conf.getBoolean("spark.oap.sql.columnar.hashCompare", defaultValue = false)

--- a/core/src/main/scala/com/intel/oap/execution/BroadcastColumnarRDD.scala
+++ b/core/src/main/scala/com/intel/oap/execution/BroadcastColumnarRDD.scala
@@ -17,15 +17,11 @@
 
 package com.intel.oap.execution
 
-import com.intel.oap.ColumnarPluginConfig
-import com.intel.oap.expression.ConverterUtils
 import com.intel.oap.vectorized.CloseableColumnBatchIterator
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 private final case class BroadcastColumnarRDDPartition(index: Int) extends Partition
@@ -41,9 +37,7 @@ case class BroadcastColumnarRDD(
     (0 until numPartitioning).map { index => new BroadcastColumnarRDDPartition(index) }.toArray
   }
   override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
-    val timeout: Int = SQLConf.get.broadcastTimeout.toInt
     val relation = inputByteBuf.value.asReadOnlyCopy
-    relation.countDownClose(timeout)
     new CloseableColumnBatchIterator(relation.getColumnarBatchAsIter)
   }
 }

--- a/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
+++ b/core/src/main/scala/com/intel/oap/execution/ColumnarShuffledHashJoinExec.scala
@@ -449,7 +449,6 @@ case class ColumnarShuffledHashJoinExec(
 
     val signature = getCodeGenSignature(hashTableType)
     val listJars = uploadAndListJars(signature)
-    val timeout = ColumnarPluginConfig.getConf(sparkConf).broadcastCacheTimeout
     val hashRelationBatchHolder: ListBuffer[ColumnarBatch] = ListBuffer()
 
     if (hashTableType == 1) {

--- a/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ConverterUtils.scala
@@ -121,11 +121,16 @@ object ConverterUtils extends Logging {
         schema = new Schema(vectors.map(_.getValueVector().getField).asJava)
         MessageSerializer.serialize(channel, schema, option)
       }
-      MessageSerializer.serialize(
-        channel,
-        ConverterUtils
-          .createArrowRecordBatch(columnarBatch.numRows, vectors.map(_.getValueVector)),
-        option)
+      val batch = ConverterUtils
+          .createArrowRecordBatch(columnarBatch.numRows, vectors.map(_.getValueVector))
+      try {
+        MessageSerializer.serialize(
+          channel,
+          batch,
+          option)
+      } finally {
+        batch.close()
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -127,12 +127,9 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan) 
         while (iter.hasNext) {
           val batch = iter.next
           if (batch.numRows > 0) {
-            (0 until batch.numCols).foreach(i =>
-              batch.column(i).asInstanceOf[ArrowWritableColumnVector].retain())
             _input += batch
             numRows += batch.numRows
             val dep_rb = ConverterUtils.createArrowRecordBatch(batch)
-            batch.close()
             hashRelationKernel.evaluate(dep_rb)
             ConverterUtils.releaseArrowRecordBatch(dep_rb)
           }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -132,6 +132,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan) 
             _input += batch
             numRows += batch.numRows
             val dep_rb = ConverterUtils.createArrowRecordBatch(batch)
+            batch.close()
             hashRelationKernel.evaluate(dep_rb)
             ConverterUtils.releaseArrowRecordBatch(dep_rb)
           }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -134,6 +134,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan) 
             ConverterUtils.releaseArrowRecordBatch(dep_rb)
           }
         }
+        // Note: Do not close this object manually. GC will take over that via Cleaner for ColumnarHashedRelation
         val hashRelationResultIterator = hashRelationKernel.finishByIterator()
         val hashRelationObj = hashRelationResultIterator.nextHashRelationObject()
         hashRelationKernel.close()

--- a/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
@@ -123,8 +123,15 @@ object ColumnarHashedRelation {
       var arrowColumnarBatch: Array[ColumnarBatch]) extends Runnable {
 
     override def run(): Unit = {
-      hashRelationObj.close()
-      arrowColumnarBatch.foreach(_.close)
+      try {
+        Option(hashRelationObj).foreach(_.close())
+        Option(arrowColumnarBatch).foreach(_.foreach(_.close))
+      } catch {
+        case e: Exception =>
+          // We should suppress all possible errors in Cleaner to prevent JVM from being shut down
+          System.err.println("ColumnarHashedRelation: Error running deaallocator")
+          e.printStackTrace()
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/ColumnarHashedRelation.scala
@@ -18,17 +18,15 @@
 package org.apache.spark.sql.execution
 
 import java.io._
-import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
-import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+
 import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.intel.oap.expression.ConverterUtils
 import com.intel.oap.vectorized.{ArrowWritableColumnVector, SerializableObject}
-import org.apache.spark.util.{KnownSizeEstimation, Utils}
-import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
-import java.util.concurrent.atomic.AtomicBoolean
+import org.apache.spark.sql.execution.ColumnarHashedRelation.Deallocator
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.KnownSizeEstimation
+import sun.misc.Cleaner
 
 class ColumnarHashedRelation(
     var hashRelationObj: SerializableObject,
@@ -37,66 +35,38 @@ class ColumnarHashedRelation(
     extends Externalizable
     with KryoSerializable
     with KnownSizeEstimation {
-  val refCnt: AtomicInteger = new AtomicInteger()
-  val closed: AtomicBoolean = new AtomicBoolean()
 
   def this() = {
     this(null, null, 0)
   }
 
+  private def createCleaner(): Unit = {
+    Cleaner.create(this, new Deallocator(hashRelationObj, arrowColumnarBatch))
+  }
+
+  createCleaner()
+
   def asReadOnlyCopy(): ColumnarHashedRelation = {
     //new ColumnarHashedRelation(hashRelationObj, arrowColumnarBatch, arrowColumnarBatchSize)
-    refCnt.incrementAndGet()
     this
   }
 
   override def estimatedSize: Long = 0
 
-  def close(waitTime: Int): Future[Int] = Future {
-    Thread.sleep(waitTime * 1000)
-    if (refCnt.get == 0) {
-      if (!closed.getAndSet(true)) {
-        hashRelationObj.close
-        arrowColumnarBatch.foreach(_.close)
-      }
-    }
-    refCnt.get
-  }
-
-  def countDownClose(waitTime: Int = -1): Unit = {
-    val curRefCnt = refCnt.decrementAndGet()
-    if (waitTime == -1) return
-    if (curRefCnt == 0) {
-      close(waitTime).onComplete {
-        case Success(resRefCnt) => {}
-        case Failure(e) =>
-          System.err.println(s"Failed to close ColumnarHashedRelation, exception = $e")
-      }
-    }
-  }
-
-  override def finalize(): Unit = {
-    if (!closed.getAndSet(true)) {
-      hashRelationObj.close
-      arrowColumnarBatch.foreach(_.close)
-    }
-  }
-
   override def writeExternal(out: ObjectOutput): Unit = {
-    if (closed.get()) return
     out.writeObject(hashRelationObj)
     val rawArrowData = ConverterUtils.convertToNetty(arrowColumnarBatch)
     out.writeObject(rawArrowData)
   }
 
   override def write(kryo: Kryo, out: Output): Unit = {
-    if (closed.get()) return
     kryo.writeObject(out, hashRelationObj)
     val rawArrowData = ConverterUtils.convertToNetty(arrowColumnarBatch)
     kryo.writeObject(out, rawArrowData)
   }
 
   override def readExternal(in: ObjectInput): Unit = {
+    createCleaner()
     hashRelationObj = in.readObject().asInstanceOf[SerializableObject]
     val rawArrowData = in.readObject().asInstanceOf[Array[Byte]]
     arrowColumnarBatchSize = rawArrowData.length
@@ -110,6 +80,7 @@ class ColumnarHashedRelation(
   }
 
   override def read(kryo: Kryo, in: Input): Unit = {
+    createCleaner()
     hashRelationObj =
       kryo.readObject(in, classOf[SerializableObject]).asInstanceOf[SerializableObject]
     val rawArrowData = kryo.readObject(in, classOf[Array[Byte]]).asInstanceOf[Array[Byte]]
@@ -129,9 +100,6 @@ class ColumnarHashedRelation(
   }
 
   def getColumnarBatchAsIter: Iterator[ColumnarBatch] = {
-    if (closed.get())
-      throw new InvalidObjectException(
-        s"can't getColumnarBatchAsIter from a deleted ColumnarHashedRelation.")
     new Iterator[ColumnarBatch] {
       var idx = 0
       val total_len = arrowColumnarBatch.length
@@ -147,5 +115,16 @@ class ColumnarHashedRelation(
       }
     }
   }
+}
+object ColumnarHashedRelation {
 
+  private class Deallocator (
+      var hashRelationObj: SerializableObject,
+      var arrowColumnarBatch: Array[ColumnarBatch]) extends Runnable {
+
+    override def run(): Unit = {
+      hashRelationObj.close()
+      arrowColumnarBatch.foreach(_.close)
+    }
+  }
 }

--- a/core/src/test/java/com/intel/oap/tpch/MallocUtils.java
+++ b/core/src/test/java/com/intel/oap/tpch/MallocUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.oap.tpch;
+
+import com.intel.oap.vectorized.JniUtils;
+
+import java.io.IOException;
+
+public class MallocUtils {
+
+  static {
+    try {
+      JniUtils.getInstance();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Visible for testing: Try turning back allocated native memory to OS. This might have no effect
+   * when using Jemalloc.
+   */
+  static native void mallocTrim();
+
+  /**
+   * Visible for testing: Print malloc statistics.
+   */
+  static native void mallocStats();
+}

--- a/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
+++ b/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
@@ -484,10 +484,13 @@ class MemoryUsageTest extends QueryTest with SharedSparkSession {
         createTPCHTables()
         writeCommentLine("```")
         writeCommentLine("Before suite starts: %s".format(genReportLine()))
-        (1 to 30).foreach { executionId =>
+        (1 to 20).foreach { executionId =>
           writeCommentLine("Iteration %d:".format(executionId))
           (1 to 22).foreach(i => {
             runTPCHQuery(i, executionId)
+            MallocUtils.mallocTrim()
+            System.gc()
+            System.gc()
             writeCommentLine("  Query %d: %s".format(i, genReportLine()))
             ramMonitor.writeImage(commentImageOutputPath)
           })

--- a/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
+++ b/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.{QueryTest, Row, SaveMode}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.codehaus.jackson.map.ObjectMapper
 import org.knowm.xchart.{BitmapEncoder, XYChartBuilder}

--- a/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
+++ b/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
@@ -484,7 +484,7 @@ class MemoryUsageTest extends QueryTest with SharedSparkSession {
         createTPCHTables()
         writeCommentLine("```")
         writeCommentLine("Before suite starts: %s".format(genReportLine()))
-        (1 to 5).foreach { executionId =>
+        (1 to 30).foreach { executionId =>
           writeCommentLine("Iteration %d:".format(executionId))
           (1 to 22).foreach(i => {
             runTPCHQuery(i, executionId)

--- a/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
+++ b/core/src/test/scala/com/intel/oap/tpch/MemoryUsageTest.scala
@@ -71,7 +71,7 @@ class MemoryUsageTest extends QueryTest with SharedSparkSession {
         .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
         //          .set("spark.sql.autoBroadcastJoinThreshold", "1")
         .set("spark.unsafe.exceptionOnMemoryLeak", "false")
-        .set("spark.sql.columnar.sort.broadcast.cache.timeout", "600")
+        .set("spark.network.io.preferDirectBufs", "false")
     return conf
   }
 

--- a/cpp/src/codegen/common/hash_relation.h
+++ b/cpp/src/codegen/common/hash_relation.h
@@ -155,6 +155,16 @@ class HashRelation {
     return arrow::Status::NotImplemented("HashRelation AppendKeyColumn is abstract.");
   }
 
+  arrow::Status Minimize() {
+    if (hash_table_ == nullptr) {
+      return arrow::Status::OK();
+    }
+    if (shrinkToFit(hash_table_)) {
+      return arrow::Status::OK();
+    }
+    return arrow::Status::Invalid("Error minimizing hash table");
+  }
+
   arrow::Status AppendKeyColumn(
       std::shared_ptr<arrow::Array> in,
       const std::vector<std::shared_ptr<UnsafeArray>>& payloads) {

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -26,6 +26,7 @@
 #include <arrow/record_batch.h>
 #include <arrow/util/compression.h>
 #include <jni.h>
+#include <malloc.h>
 
 #include <iostream>
 #include <memory>
@@ -1600,6 +1601,20 @@ Java_com_intel_oap_vectorized_ShuffleDecompressionJniWrapper_decompress(
 JNIEXPORT void JNICALL Java_com_intel_oap_vectorized_ShuffleDecompressionJniWrapper_close(
     JNIEnv* env, jobject, jlong schema_holder_id) {
   decompression_schema_holder_.Erase(schema_holder_id);
+}
+
+JNIEXPORT void JNICALL
+Java_com_intel_oap_tpch_MallocUtils_mallocTrim(JNIEnv* env, jobject obj) {
+//  malloc_stats_print(statsPrint, nullptr, nullptr);
+  std::cout << "Calling malloc_trim... " << std::endl;
+  malloc_trim(0);
+}
+
+JNIEXPORT void JNICALL
+Java_com_intel_oap_tpch_MallocUtils_mallocStats(JNIEnv* env, jobject obj) {
+//  malloc_stats_print(statsPrint, nullptr, nullptr);
+  std::cout << "Calling malloc_stats... " << std::endl;
+  malloc_stats();
 }
 
 #ifdef __cplusplus

--- a/cpp/src/third_party/row_wise_memory/hashMap.h
+++ b/cpp/src/third_party/row_wise_memory/hashMap.h
@@ -199,6 +199,18 @@ static inline int getValueFromBytesMapByOffset(unsafeHashMap* hashMap,
   return KeyAddressOffset;
 }
 
+static inline bool shrinkToFit(unsafeHashMap* hashMap) {
+  if (hashMap->cursor >= hashMap->mapSize) {
+    return true;
+  }
+  auto pool = (arrow::MemoryPool*)hashMap->pool;
+  auto status = pool->Reallocate(hashMap->mapSize, hashMap->cursor, (uint8_t**)&hashMap->bytesMap);
+  if (status.ok()) {
+    hashMap->mapSize = hashMap->cursor;
+  }
+  return status.ok();
+}
+
 static inline bool growHashBytesMap(unsafeHashMap* hashMap) {
   std::cout << "growHashBytesMap" << std::endl;
   int oldSize = hashMap->mapSize;


### PR DESCRIPTION
#45 

This is ideally to fix leaks and reduce process RSS during BHJ-related query execution. Still doing a final check for memory segmentation and other minor stuffs.

Checklist:

1. BHJ: Fix unclosed hash map on driver
2. BHJ: Fix unclosed input batches on driver
3. Remove use of unreliable  JVM API `finalize()`
4. Remove ref-count for java-side hash maps (we should avoid creating more manual ref-count logic in JVM code unless performance getting really worse)
5. Remove option `broadcastCacheTimeout` which is no longer needed.