### PR TITLE
[NSE-53]Partial fix Q24a/Q24b tail SHJ task materialization performance issue

### DIFF
--- a/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -22,6 +22,9 @@
 #include <cstdint>
 #include <vector>
 
+#include "codegen/arrow_compute/ext/array_item_index.h"
+#include "utils/macros.h"
+
 namespace sparkcolumnarplugin {
 namespace codegen {
 namespace arrowcompute {
@@ -42,7 +45,12 @@ class AppenderBase {
     return arrow::Status::NotImplemented("AppenderBase PopArray is abstract.");
   }
 
-  virtual arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) {
+  virtual arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                               int repeated = 1) {
+    return arrow::Status::NotImplemented("AppenderBase Append is abstract.");
+  }
+
+  virtual arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
     return arrow::Status::NotImplemented("AppenderBase Append is abstract.");
   }
 
@@ -67,10 +75,14 @@ template <typename DataType, typename Enable = void>
 class ArrayAppender {};
 
 template <typename T>
-using enable_if_not_boolean = std::enable_if_t<!arrow::is_boolean_type<T>::value>;
+using is_number_or_date = std::integral_constant<bool, arrow::is_number_type<T>::value ||
+                                                           arrow::is_date_type<T>::value>;
+
+template <typename DataType, typename R = void>
+using enable_if_number_or_date = std::enable_if_t<is_number_or_date<DataType>::value, R>;
 
 template <typename DataType>
-class ArrayAppender<DataType, enable_if_not_boolean<DataType>> : public AppenderBase {
+class ArrayAppender<DataType, enable_if_number_or_date<DataType>> : public AppenderBase {
  public:
   ArrayAppender(arrow::compute::FunctionContext* ctx, AppenderType type = left)
       : ctx_(ctx), type_(type) {
@@ -85,27 +97,121 @@ class ArrayAppender<DataType, enable_if_not_boolean<DataType>> : public Appender
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
     cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
 
   arrow::Status PopArray() override {
     cached_arr_.pop_back();
+    has_null_ = false;
     return arrow::Status::OK();
   }
 
-  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
-    if (!cached_arr_[array_id]->IsNull(item_id)) {
-      auto val = cached_arr_[array_id]->GetView(item_id);
-      return builder_->Append(cached_arr_[array_id]->GetView(item_id));
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
     } else {
-      return builder_->AppendNull();
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      std::vector<CType> values;
+      values.resize(repeated, val);
+      RETURN_NOT_OK(builder_->AppendValues(values.data(), repeated));
     }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        RETURN_NOT_OK(builder_->AppendNull());
+      } else {
+        RETURN_NOT_OK(builder_->Append(cached_arr_[tmp.array_id]->GetView(tmp.id)));
+      }
+    }
+    return arrow::Status::OK();
   }
 
   arrow::Status AppendNull() override { return builder_->AppendNull(); }
 
   arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
-    return builder_->Finish(out_);
+    auto status = builder_->Finish(out_);
+    return status;
+  }
+
+  arrow::Status Reset() override {
+    builder_->Reset();
+    return arrow::Status::OK();
+  }
+
+ private:
+  using BuilderType_ = typename arrow::TypeTraits<DataType>::BuilderType;
+  using ArrayType_ = typename arrow::TypeTraits<DataType>::ArrayType;
+  using CType = typename arrow::TypeTraits<DataType>::CType;
+  std::unique_ptr<BuilderType_> builder_;
+  std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
+  arrow::compute::FunctionContext* ctx_;
+  AppenderType type_;
+  bool has_null_ = false;
+};
+
+template <typename DataType>
+class ArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
+    : public AppenderBase {
+ public:
+  ArrayAppender(arrow::compute::FunctionContext* ctx, AppenderType type = left)
+      : ctx_(ctx), type_(type) {
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(ctx_->memory_pool(), arrow::TypeTraits<DataType>::type_singleton(),
+                       &array_builder);
+    builder_.reset(arrow::internal::checked_cast<BuilderType_*>(array_builder.release()));
+  }
+  ~ArrayAppender() {}
+
+  AppenderType GetType() override { return type_; }
+  arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
+    auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
+    cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status PopArray() override {
+    cached_arr_.pop_back();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
+    } else {
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      for (int i = 0; i < repeated; i++) {
+        RETURN_NOT_OK(builder_->Append(val));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        RETURN_NOT_OK(builder_->AppendNull());
+      } else {
+        RETURN_NOT_OK(builder_->Append(cached_arr_[tmp.array_id]->GetView(tmp.id)));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status AppendNull() override { return builder_->AppendNull(); }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
+    auto status = builder_->Finish(out_);
+    return status;
   }
 
   arrow::Status Reset() override {
@@ -120,6 +226,7 @@ class ArrayAppender<DataType, enable_if_not_boolean<DataType>> : public Appender
   std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
   arrow::compute::FunctionContext* ctx_;
   AppenderType type_;
+  bool has_null_ = false;
 };
 
 template <typename DataType>
@@ -138,21 +245,39 @@ class ArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public Appen
   arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
     auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
     cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
     return arrow::Status::OK();
   }
 
   arrow::Status PopArray() override {
     cached_arr_.pop_back();
+    has_null_ = false;
     return arrow::Status::OK();
   }
 
-  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
-    if (!cached_arr_[array_id]->IsNull(item_id)) {
-      auto val = cached_arr_[array_id]->GetView(item_id);
-      return builder_->Append(cached_arr_[array_id]->GetView(item_id));
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
     } else {
-      return builder_->AppendNull();
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      for (int i = 0; i < repeated; i++) {
+        RETURN_NOT_OK(builder_->Append(val));
+      }
     }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        RETURN_NOT_OK(builder_->AppendNull());
+      } else {
+        RETURN_NOT_OK(builder_->Append(cached_arr_[tmp.array_id]->GetView(tmp.id)));
+      }
+    }
+    return arrow::Status::OK();
   }
 
   arrow::Status AppendNull() override { return builder_->AppendNull(); }
@@ -160,7 +285,8 @@ class ArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public Appen
   arrow::Status AppendExistence(bool is_exist) { return builder_->Append(is_exist); }
 
   arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
-    return builder_->Finish(out_);
+    auto status = builder_->Finish(out_);
+    return status;
   }
 
   arrow::Status Reset() override {
@@ -175,6 +301,7 @@ class ArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public Appen
   std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
   arrow::compute::FunctionContext* ctx_;
   AppenderType type_;
+  bool has_null_ = false;
 };
 
 #define PROCESS_SUPPORTED_TYPES(PROCESS) \

--- a/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
+++ b/cpp/src/codegen/arrow_compute/ext/conditioned_probe_kernel.cc
@@ -627,6 +627,7 @@ class ConditionedProbeKernel::Impl {
           : hash_relation_(hash_relation), appender_list_(appender_list) {}
       uint64_t Evaluate(std::shared_ptr<arrow::Array> key_array,
                         const arrow::ArrayVector& key_payloads) override {
+        struct timespec start, end;
         auto typed_key_array = std::dynamic_pointer_cast<ArrayType>(key_array);
         std::vector<std::shared_ptr<UnsafeArray>> payloads;
         int i = 0;
@@ -705,16 +706,15 @@ class ConditionedProbeKernel::Impl {
           if (index == -1) {
             continue;
           }
-          for (auto tmp : hash_relation_->GetItemListByIndex(index)) {
-            for (auto appender : appender_list_) {
-              if (appender->GetType() == AppenderBase::left) {
-                THROW_NOT_OK(appender->Append(tmp.array_id, tmp.id));
-              } else {
-                THROW_NOT_OK(appender->Append(0, i));
-              }
+          auto index_list = hash_relation_->GetItemListByIndex(index);
+          for (auto appender : appender_list_) {
+            if (appender->GetType() == AppenderBase::left) {
+              THROW_NOT_OK(appender->Append(index_list));
+            } else {
+              THROW_NOT_OK(appender->Append(0, i, index_list.size()));
             }
-            out_length += 1;
           }
+          out_length += index_list.size();
         }
         return out_length;
       }
@@ -831,16 +831,15 @@ class ConditionedProbeKernel::Impl {
             out_length += 1;
             continue;
           }
-          for (auto tmp : hash_relation_->GetItemListByIndex(index)) {
-            for (auto appender : appender_list_) {
-              if (appender->GetType() == AppenderBase::left) {
-                THROW_NOT_OK(appender->Append(tmp.array_id, tmp.id));
-              } else {
-                THROW_NOT_OK(appender->Append(0, i));
-              }
+          auto index_list = hash_relation_->GetItemListByIndex(index);
+          for (auto appender : appender_list_) {
+            if (appender->GetType() == AppenderBase::left) {
+              THROW_NOT_OK(appender->Append(index_list));
+            } else {
+              THROW_NOT_OK(appender->Append(0, i, index_list.size()));
             }
-            out_length += 1;
           }
+          out_length += index_list.size();
         }
         return out_length;
       }
@@ -1228,16 +1227,15 @@ class ConditionedProbeKernel::Impl {
           if (index == -1) {
             continue;
           }
-          for (auto tmp : typed_hash_relation_->GetItemListByIndex(index)) {
-            for (auto appender : appender_list_) {
-              if (appender->GetType() == AppenderBase::left) {
-                THROW_NOT_OK(appender->Append(tmp.array_id, tmp.id));
-              } else {
-                THROW_NOT_OK(appender->Append(0, i));
-              }
+          auto index_list = typed_hash_relation_->GetItemListByIndex(index);
+          for (auto appender : appender_list_) {
+            if (appender->GetType() == AppenderBase::left) {
+              THROW_NOT_OK(appender->Append(index_list));
+            } else {
+              THROW_NOT_OK(appender->Append(0, i, index_list.size()));
             }
-            out_length += 1;
           }
+          out_length += index_list.size();
         }
         return out_length;
       }
@@ -1278,16 +1276,15 @@ class ConditionedProbeKernel::Impl {
             out_length += 1;
             continue;
           }
-          for (auto tmp : typed_hash_relation_->GetItemListByIndex(index)) {
-            for (auto appender : appender_list_) {
-              if (appender->GetType() == AppenderBase::left) {
-                THROW_NOT_OK(appender->Append(tmp.array_id, tmp.id));
-              } else {
-                THROW_NOT_OK(appender->Append(0, i));
-              }
+          auto index_list = typed_hash_relation_->GetItemListByIndex(index);
+          for (auto appender : appender_list_) {
+            if (appender->GetType() == AppenderBase::left) {
+              THROW_NOT_OK(appender->Append(index_list));
+            } else {
+              THROW_NOT_OK(appender->Append(0, i, index_list.size()));
             }
-            out_length += 1;
           }
+          out_length += index_list.size();
         }
         return out_length;
       }

--- a/cpp/src/precompile/type_traits.h
+++ b/cpp/src/precompile/type_traits.h
@@ -42,6 +42,9 @@ using is_number_like_type =
     std::integral_constant<bool, is_number_like<T>::value || is_date_type<T>::value>;
 
 template <typename T>
+using enable_if_boolean = std::enable_if_t<is_boolean_type<T>::value>;
+
+template <typename T>
 using enable_if_number = std::enable_if_t<is_number_like_type<T>::value>;
 
 template <typename T>

--- a/cpp/src/tests/arrow_compute_test_join_wocg.cc
+++ b/cpp/src/tests/arrow_compute_test_join_wocg.cc
@@ -91,7 +91,8 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestProjectKeyInnerJoin) {
       arrow::schema({table0_f0, table0_f1, table0_f2, table1_f0, table1_f1});
 
   std::shared_ptr<CodeGenerator> expr_probe;
-  auto result = CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  arrow::compute::FunctionContext ctx;
+  auto result = CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f1, table0_f2}, &expr_probe, true);
 }
 
@@ -147,11 +148,12 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestStringInnerJoin) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
   ASSERT_NOT_OK(CreateCodeGenerator(
-      schema_table_1, {probeArrays_expr},
+      ctx.memory_pool(), schema_table_1, {probeArrays_expr},
       {table0_f0, table0_f1, table0_f2, table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -280,11 +282,12 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestTwoStringInnerJoin) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
   ASSERT_NOT_OK(CreateCodeGenerator(
-      schema_table_1, {probeArrays_expr},
+      ctx.memory_pool(), schema_table_1, {probeArrays_expr},
       {table0_f0, table0_f1, table0_f2, table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -406,10 +409,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestOuterJoin) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table0_f0, table0_f1, table0_f2, table1_f1},
                                     &expr_probe, true));
   ///////////////////// Calculation //////////////////
@@ -532,10 +536,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestAntiJoin) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -651,10 +656,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestSemiJoin) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -775,10 +781,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoin) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, f_exist, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -901,10 +908,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoin2) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1, f_exist}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1030,11 +1038,12 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestTwoStringInnerJoinType2) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
   ASSERT_NOT_OK(CreateCodeGenerator(
-      schema_table_1, {probeArrays_expr},
+      ctx.memory_pool(), schema_table_1, {probeArrays_expr},
       {table0_f0, table0_f1, table0_f2, table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1156,10 +1165,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestOuterJoinType2) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table0_f0, table0_f1, table0_f2, table1_f1},
                                     &expr_probe, true));
   ///////////////////// Calculation //////////////////
@@ -1282,10 +1292,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestAntiJoinType2) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1401,10 +1412,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestSemiJoinType2) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1525,10 +1537,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestExistenceJoinType2) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, f_exist, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1648,10 +1661,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestSemiJoinType2WithUInt64) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1769,10 +1783,11 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestInnerJoinType2WithUInt16) {
   auto n_hash = TreeExprBuilder::MakeFunction("standalone", {n_hash_kernel}, uint32());
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_1, {probeArrays_expr},
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_1, {probeArrays_expr},
                                     {table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;
@@ -1911,14 +1926,15 @@ TEST(TestArrowComputeWSCG, JoinWOCGTestStringInnerJoinType2LoadHashRelation) {
   auto hashRelation_expr = TreeExprBuilder::MakeExpression(n_hash, f_res);
 
   std::shared_ptr<CodeGenerator> expr_build_pre;
-  ASSERT_NOT_OK(CreateCodeGenerator(schema_table_0, {hashRelation_expr_pre}, {},
-                                    &expr_build_pre, true));
+  arrow::compute::FunctionContext ctx;
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr_pre}, {}, &expr_build_pre, true));
   std::shared_ptr<CodeGenerator> expr_build;
-  ASSERT_NOT_OK(
-      CreateCodeGenerator(schema_table_0, {hashRelation_expr}, {}, &expr_build, true));
+  ASSERT_NOT_OK(CreateCodeGenerator(ctx.memory_pool(), schema_table_0,
+                                    {hashRelation_expr}, {}, &expr_build, true));
   std::shared_ptr<CodeGenerator> expr_probe;
   ASSERT_NOT_OK(CreateCodeGenerator(
-      schema_table_1, {probeArrays_expr},
+      ctx.memory_pool(), schema_table_1, {probeArrays_expr},
       {table0_f0, table0_f1, table0_f2, table1_f0, table1_f1}, &expr_probe, true));
   ///////////////////// Calculation //////////////////
   std::shared_ptr<arrow::RecordBatch> input_batch;


### PR DESCRIPTION
Fixed: https://github.com/oap-project/native-sql-engine/issues/53

This Issue is due to some join task in 24a/24b will expand input table 1000 times, which leads to output result contains 100 million + numRows, so the materialization is extremely slow

in this PR, we tried to accelerate materialization 

TODO:
If we can merge this Join with following Aggregate in a whole stage code gen, this issue may be fully fixed.