### PR TITLE
[NSE-58]Fix empty input issue when DPP enabled

### DIFF
--- a/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarAggregation.scala
@@ -511,6 +511,12 @@ class ColumnarAggregation(
             }
             numInputBatches += 1
           }
+          if (processedNumRows == 0) {
+            data_loaded = true
+            aggrTime += NANOSECONDS.toMillis(eval_elapse)
+            nextBatch = false
+            return false
+          }
           if (groupingFieldList.size > 0) {
             val beforeFinish = System.nanoTime()
             result_iterator = aggregator.finishByIterator()

--- a/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -137,7 +137,7 @@ class ColumnarSorter(
       var has_next: Boolean = true
 
       override def hasNext: Boolean = {
-        if (sort_iterator == null) {
+        if (has_next && sort_iterator == null) {
           while (cbIterator.hasNext) {
             cb = cbIterator.next()
 
@@ -148,14 +148,18 @@ class ColumnarSorter(
           }
 
           val beforeSort = System.nanoTime()
-          sort_iterator = sorter.finishByIterator();
+          if (processedNumRows > 0) {
+            sort_iterator = sorter.finishByIterator();
+          }
           sort_elapse += System.nanoTime() - beforeSort
           total_elapse += System.nanoTime() - beforeSort
         }
-        if (sort_iterator.hasNext()) {
+        if (sort_iterator != null && sort_iterator.hasNext()) {
           return true
         } else {
+          has_next = false
           inputBatchHolder.foreach(cb => cb.close())
+          inputBatchHolder.clear
           return false
         }
       }


### PR DESCRIPTION
Fixed: https://github.com/oap-project/native-sql-engine/issues/58

Noticed that there is remains some queries with DPP enabled, some tasks' input will be totally empty, and this may leads to seg fault for ColumnarSort or ColumnarAggr, fix here
