### PR TITLE
[NSE-64] fix memleak in sort when SMJ is disabled

### DIFF
--- a/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
+++ b/core/src/main/scala/com/intel/oap/expression/ColumnarSorter.scala
@@ -92,6 +92,8 @@ class ColumnarSorter(
     elapse.set(NANOSECONDS.toMillis(total_elapse))
     sortTime.set(NANOSECONDS.toMillis(sort_elapse))
     shuffleTime.set(NANOSECONDS.toMillis(shuffle_elapse))
+    inputBatchHolder.foreach(cb => cb.close())
+    inputBatchHolder.clear
     if (sorter != null) {
       sorter.close()
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fixes the memleak in sort when SMJ is disabled, caused by batch close was not called by the consumer of sort operator (C2R).
fixes: https://github.com/oap-project/native-sql-engine/issues/64

## How was this patch tested?

verified on TPC-DS sf1000

