### PR TITLE
[NSE-81] add missing setNulls methods in ArrowWritableColumnVector

### DIFF
--- a/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
+++ b/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
@@ -1726,6 +1726,7 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
       writer.setNull(rowId);
     }
 
+    @Override
     final void setNulls(int rowId, int count) {
       for (int i = 0; i < count; i++) {
         writer.setNull(rowId + i);

--- a/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
+++ b/core/src/main/java/com/intel/oap/vectorized/ArrowWritableColumnVector.java
@@ -1695,6 +1695,13 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     }
 
     @Override
+    final void setNulls(int rowId, int count) {
+      for (int i = 0; i < count; i++) {
+        writer.setNull(rowId + i);
+      }
+    }
+
+    @Override
     final void setBytes(int rowId, int count, byte[] src, int srcIndex) {
       writer.setSafe(rowId, src, srcIndex, count);
     }
@@ -1717,6 +1724,12 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     @Override
     final void setNull(int rowId) {
       writer.setNull(rowId);
+    }
+
+    final void setNulls(int rowId, int count) {
+      for (int i = 0; i < count; i++) {
+        writer.setNull(rowId + i);
+      }
     }
   }
 
@@ -1744,6 +1757,13 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     final void setNull(int rowId) {
       writer.setNull(rowId);
     }
+
+    @Override
+    final void setNulls(int rowId, int count) {
+      for (int i = 0; i < count; i++) {
+        writer.setNull(rowId + i);
+      }
+    }
   }
 
   private static class TimestampWriter extends ArrowVectorWriter {
@@ -1769,6 +1789,13 @@ public final class ArrowWritableColumnVector extends WritableColumnVector {
     @Override
     final void setNull(int rowId) {
       writer.setNull(rowId);
+    }
+
+    @Override
+    final void setNulls(int rowId, int count) {
+      for (int i = 0; i < count; i++) {
+        writer.setNull(rowId + i);
+      }
     }
   }
 


### PR DESCRIPTION
fixes: #81 
Miss some setNulls implementation in ArrowWritableCV
