### PR TITLE
[NSE-134] Update input metrics during reading

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/util/OASPackageBridge.scala
+++ b/core/src/main/scala/org/apache/spark/sql/util/OASPackageBridge.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util
+
+import org.apache.spark.executor.InputMetrics
+
+/**
+ * Bridge to package org.apache.spark.
+ */
+object OASPackageBridge {
+  implicit class InputMetricsWrapper(val m: InputMetrics) {
+    def bridgeIncBytesRead(v: Long): Unit = {
+      m.incBytesRead(v)
+    }
+  }
+}


### PR DESCRIPTION
fixes: #134 

This is to add input size to stage metrics shown on UI when using columnar plugin.
Only available in DataSourceV2.

![image](https://user-images.githubusercontent.com/11284395/109449364-35644400-7a83-11eb-87f3-2366809adf1f.png)
