### PR TITLE
[NSE-170]improve sort shuffle code

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/expression_codegen_visitor.cc
@@ -507,8 +507,8 @@ arrow::Status ExpressionCodegenVisitor::Visit(const gandiva::FunctionNode& node)
     } else {
       auto childNode = node.children().at(0);
       auto childType =
-        std::dynamic_pointer_cast<arrow::Decimal128Type>(childNode->return_type());
-      fix_ss << "round(" << child_visitor_list[0]->GetResult() << ", " 
+          std::dynamic_pointer_cast<arrow::Decimal128Type>(childNode->return_type());
+      fix_ss << "round(" << child_visitor_list[0]->GetResult() << ", "
              << childType->precision() << ", " << childType->scale() << ", &overflow";
     }
     if (child_visitor_list.size() > 1) {

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -692,11 +692,12 @@ extern "C" void MakeCodeGen(arrow::compute::ExecContext* ctx,
       auto length = (total_length_ - offset_) > batch_size_ ? batch_size_
                                                             : (total_length_ - offset_);
       uint64_t count = 0;
-      while (count < length) {
-        auto item = indices_begin_ + offset_ + count++;
-        for (int i = 0; i < col_num_; i++) {
+      for (int i = 0; i < col_num_; i++) {
+        while (count < length) {
+          auto item = indices_begin_ + offset_ + count++;
           RETURN_NOT_OK(appender_list_[i]->Append(item->array_id, item->id));
         }
+        count = 0;
       }
       offset_ += length;
       ArrayList arrays;

--- a/native-sql-engine/cpp/src/precompile/builder.cc
+++ b/native-sql-engine/cpp/src/precompile/builder.cc
@@ -69,10 +69,10 @@ class StringBuilder::Impl : public arrow::StringBuilder {
 StringBuilder::StringBuilder(arrow::MemoryPool* pool) {
   impl_ = std::make_shared<Impl>(pool);
 }
-arrow::Status StringBuilder::Append(arrow::util::string_view value) {
+arrow::Status StringBuilder::Append(const arrow::util::string_view& value) {
   return impl_->Append(value);
 }
-arrow::Status StringBuilder::AppendString(std::string value) {
+arrow::Status StringBuilder::AppendString(const std::string& value) {
   return impl_->Append(arrow::util::string_view(value));
 }
 arrow::Status StringBuilder::AppendNull() { return impl_->AppendNull(); }
@@ -94,7 +94,7 @@ Decimal128Builder::Decimal128Builder(std::shared_ptr<arrow::DataType> type,
                                      arrow::MemoryPool* pool) {
   impl_ = std::make_shared<Impl>(type, pool);
 }
-arrow::Status Decimal128Builder::Append(arrow::Decimal128 value) {
+arrow::Status Decimal128Builder::Append(const arrow::Decimal128& value) {
   return impl_->Append(value);
 }
 arrow::Status Decimal128Builder::AppendNull() { return impl_->AppendNull(); }

--- a/native-sql-engine/cpp/src/precompile/builder.cc
+++ b/native-sql-engine/cpp/src/precompile/builder.cc
@@ -32,7 +32,7 @@ namespace precompile {
   };                                                                                    \
                                                                                         \
   TYPENAME::TYPENAME(arrow::MemoryPool* pool) { impl_ = std::make_shared<Impl>(pool); } \
-  arrow::Status TYPENAME::Append(CTYPE value) { return impl_->Append(value); }          \
+  arrow::Status TYPENAME::Append(const CTYPE& value) { return impl_->Append(value); }   \
   arrow::Status TYPENAME::AppendNull() { return impl_->AppendNull(); }                  \
   arrow::Status TYPENAME::Reserve(int64_t length) { return impl_->Reserve(length); }    \
   arrow::Status TYPENAME::AppendNulls(int64_t length) {                                 \

--- a/native-sql-engine/cpp/src/precompile/builder.h
+++ b/native-sql-engine/cpp/src/precompile/builder.h
@@ -53,8 +53,8 @@ TYPED_BUILDER_DEFINE(Date64Builder, int64_t)
 class StringBuilder {
  public:
   StringBuilder(arrow::MemoryPool* pool);
-  arrow::Status Append(arrow::util::string_view val);
-  arrow::Status AppendString(std::string val);
+  arrow::Status Append(const arrow::util::string_view& val);
+  arrow::Status AppendString(const std::string& val);
   arrow::Status AppendNull();
   arrow::Status Finish(std::shared_ptr<arrow::Array>* out);
   arrow::Status Reset();
@@ -67,7 +67,7 @@ class StringBuilder {
 class Decimal128Builder {
  public:
   Decimal128Builder(std::shared_ptr<arrow::DataType> type, arrow::MemoryPool* pool);
-  arrow::Status Append(arrow::Decimal128 val);
+  arrow::Status Append(const arrow::Decimal128& val);
   arrow::Status AppendNull();
   arrow::Status Reserve(int64_t);
   arrow::Status AppendNulls(int64_t);

--- a/native-sql-engine/cpp/src/precompile/builder.h
+++ b/native-sql-engine/cpp/src/precompile/builder.h
@@ -24,7 +24,7 @@ namespace precompile {
   class TYPENAME {                                            \
    public:                                                    \
     TYPENAME(arrow::MemoryPool* pool);                        \
-    arrow::Status Append(TYPE val);                           \
+    arrow::Status Append(const TYPE& val);                    \
     arrow::Status AppendNull();                               \
     arrow::Status Reserve(int64_t);                           \
     arrow::Status AppendNulls(int64_t);                       \

--- a/native-sql-engine/cpp/src/precompile/gandiva.h
+++ b/native-sql-engine/cpp/src/precompile/gandiva.h
@@ -202,15 +202,12 @@ bool equal_with_nan(double left, double right) {
   return left == right;
 }
 
-arrow::Decimal128 round(arrow::Decimal128 in, 
-                        int32_t original_precision,
-                        int32_t original_scale,
-                        bool* overflow_,
-                        int32_t res_scale = 2) {
+arrow::Decimal128 round(arrow::Decimal128 in, int32_t original_precision,
+                        int32_t original_scale, bool* overflow_, int32_t res_scale = 2) {
   bool overflow = false;
   gandiva::BasicDecimalScalar128 val(in, original_precision, original_scale);
-  auto out = gandiva::decimalops::Round(val, original_precision, res_scale, 
-                                        res_scale, &overflow);
+  auto out = gandiva::decimalops::Round(val, original_precision, res_scale, res_scale,
+                                        &overflow);
   if (overflow) {
     *overflow_ = true;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch switch back to use the old logic, which seems faster on my env
```
for each column
  for each index
     builder append
```
partially reverts: 
https://github.com/oap-project/native-sql-engine/pull/104/commits/24d8b681897fc489eb3ab18eb89d08fe20ff076e

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

locally verified