### PR TITLE
[NSE-167]Fix q14a/b segfault

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/hash_relation_kernel.cc
@@ -186,10 +186,16 @@ class HashRelationKernel::Impl {
       if (num_total_cached_ > 32) {
         init_key_capacity = pow(2, ceil(log2(num_total_cached_)) + 1);
       }
+      long tmp_capacity = init_key_capacity;
       if (key_size_ != -1) {
-        init_bytes_map_capacity = init_key_capacity * 12;
+        tmp_capacity *= 12;
       } else {
-        init_bytes_map_capacity = init_key_capacity * 128;
+        tmp_capacity *= 128;
+      }
+      if (tmp_capacity > INT_MAX) {
+        init_bytes_map_capacity = INT_MAX;
+      } else {
+        init_bytes_map_capacity = tmp_capacity;
       }
       RETURN_NOT_OK(
           hash_relation_->InitHashTable(init_key_capacity, init_bytes_map_capacity));

--- a/native-sql-engine/cpp/src/codegen/common/hash_relation.h
+++ b/native-sql-engine/cpp/src/codegen/common/hash_relation.h
@@ -27,6 +27,7 @@
 #include "precompile/unsafe_array.h"
 #include "third_party/murmurhash/murmurhash32.h"
 #include "third_party/row_wise_memory/hashMap.h"
+#include "utils/macros.h"
 
 using sparkcolumnarplugin::codegen::arrowcompute::extra::ArrayItemIndex;
 using sparkcolumnarplugin::precompile::enable_if_number;
@@ -142,6 +143,11 @@ class HashRelation {
   }
 
   arrow::Status InitHashTable(int init_key_capacity, int initial_bytesmap_capacity) {
+    if (init_key_capacity < 0 || initial_bytesmap_capacity < 0) {
+      THROW_NOT_OK(arrow::Status::Invalid(
+          "initialization size is overflowed, init_key_capacity is ", init_key_capacity,
+          ", initial_bytesmap_capacity is ", initial_bytesmap_capacity));
+    }
     hash_table_ = createUnsafeHashMap(ctx_->memory_pool(), init_key_capacity,
                                       initial_bytesmap_capacity, key_size_);
     return arrow::Status::OK();


### PR DESCRIPTION
This issue is caused by when numKeys to build hashmap is too big, it will overflow hashmap size.
So we now will use IntMax to bound hashmap size.

According to test, q14a should be able to finish, while it will take extremely long to build hashMap

Fixed: https://github.com/oap-project/native-sql-engine/issues/167

Signed-off-by: Chendi Xue <chendi.xue@intel.com>
