### PR TITLE
[NSE-170] using unsafe appender

### DIFF
--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -68,6 +68,10 @@ class AppenderBase {
     return arrow::Status::NotImplemented("AppenderBase Finish is abstract.");
   }
 
+  virtual arrow::Status Reserve(uint64_t) {
+    return arrow::Status::NotImplemented("AppenderBase Reset is abstract.");
+  }
+
   virtual arrow::Status Reset() {
     return arrow::Status::NotImplemented("AppenderBase Reset is abstract.");
   }
@@ -468,6 +472,423 @@ static arrow::Status MakeAppender(arrow::compute::ExecContext* ctx,
   return arrow::Status::OK();
 }
 #undef PROCESS_SUPPORTED_TYPES
+
+
+/// unsafe appender ////
+template <typename DataType, typename Enable = void>
+class UnsafeArrayAppender {};
+
+
+template <typename DataType>
+class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>> : public AppenderBase {
+ public:
+  UnsafeArrayAppender(arrow::compute::ExecContext* ctx, AppenderType type = left)
+      : ctx_(ctx), type_(type) {
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(ctx_->memory_pool(), arrow::TypeTraits<DataType>::type_singleton(),
+                       &array_builder);
+    builder_.reset(arrow::internal::checked_cast<BuilderType_*>(array_builder.release()));
+  }
+  ~UnsafeArrayAppender() {}
+
+  AppenderType GetType() override { return type_; }
+  arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
+    auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
+    cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status PopArray() override {
+    cached_arr_.pop_back();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
+    if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
+        cached_arr_[array_id]->IsNull(item_id)) {
+      builder_->UnsafeAppendNull();
+    } else {
+      builder_->UnsafeAppend(cached_arr_[array_id]->GetView(item_id));
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
+        cached_arr_[array_id]->IsNull(item_id)) {
+      //TODO: unloop here and use unsafeappend
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
+    } else {
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      std::vector<CType> values;
+      values.resize(repeated, val);
+      //TODO: unloop here and use unsafeappend
+      RETURN_NOT_OK(builder_->AppendValues(values.data(), repeated));
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->null_count() > 0 &&
+          cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        builder_->AppendNull();
+      } else {
+        builder_->UnsafeAppend(cached_arr_[tmp.array_id]->GetView(tmp.id));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status AppendNull() override {
+    //TODO: use unsafe append
+    return builder_->AppendNull(); 
+    }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
+    auto status = builder_->Finish(out_);
+    return status;
+  }
+
+  arrow::Status Reserve(uint64_t len) override {
+    builder_->Reserve(len);
+    return arrow::Status::OK();
+  }
+  
+  arrow::Status Reset() override {
+    builder_->Reset();
+    return arrow::Status::OK();
+  }
+
+ private:
+  using BuilderType_ = typename arrow::TypeTraits<DataType>::BuilderType;
+  using ArrayType_ = typename arrow::TypeTraits<DataType>::ArrayType;
+  using CType = typename arrow::TypeTraits<DataType>::CType;
+  std::unique_ptr<BuilderType_> builder_;
+  std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
+  arrow::compute::ExecContext* ctx_;
+  AppenderType type_;
+  bool has_null_ = false;
+};
+
+//TODO(): this is a fake unsafeappende for string array
+template <typename DataType>
+class UnsafeArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
+    : public AppenderBase {
+ public:
+  UnsafeArrayAppender(arrow::compute::ExecContext* ctx, AppenderType type = left)
+      : ctx_(ctx), type_(type) {
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(ctx_->memory_pool(), arrow::TypeTraits<DataType>::type_singleton(),
+                       &array_builder);
+    builder_.reset(arrow::internal::checked_cast<BuilderType_*>(array_builder.release()));
+  }
+  ~UnsafeArrayAppender() {}
+
+  AppenderType GetType() override { return type_; }
+  arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
+    auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
+    cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status PopArray() override {
+    cached_arr_.pop_back();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
+    if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
+        cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNull());
+    } else {
+      RETURN_NOT_OK(builder_->Append(cached_arr_[array_id]->GetView(item_id)));
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
+        cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
+    } else {
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      for (int i = 0; i < repeated; i++) {
+        RETURN_NOT_OK(builder_->Append(val));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->null_count() > 0 &&
+          cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        RETURN_NOT_OK(builder_->AppendNull());
+      } else {
+        RETURN_NOT_OK(builder_->Append(cached_arr_[tmp.array_id]->GetView(tmp.id)));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status AppendNull() override { return builder_->AppendNull(); }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
+    auto status = builder_->Finish(out_);
+    return status;
+  }
+  
+  arrow::Status Reserve(uint64_t len) override {
+    //builder_->Reserve(len);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Reset() override {
+    builder_->Reset();
+    return arrow::Status::OK();
+  }
+
+ private:
+  using BuilderType_ = typename arrow::TypeTraits<DataType>::BuilderType;
+  using ArrayType_ = typename arrow::TypeTraits<DataType>::ArrayType;
+  std::unique_ptr<BuilderType_> builder_;
+  std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
+  arrow::compute::ExecContext* ctx_;
+  AppenderType type_;
+  bool has_null_ = false;
+};
+
+//TOOD(): this is a fake unsafeappender for boolean array
+template <typename DataType>
+class UnsafeArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public AppenderBase {
+ public:
+  UnsafeArrayAppender(arrow::compute::ExecContext* ctx, AppenderType type = left)
+      : ctx_(ctx), type_(type) {
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(ctx_->memory_pool(), arrow::TypeTraits<DataType>::type_singleton(),
+                       &array_builder);
+    builder_.reset(arrow::internal::checked_cast<BuilderType_*>(array_builder.release()));
+  }
+  ~UnsafeArrayAppender() {}
+
+  AppenderType GetType() override { return type_; }
+  arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
+    auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
+    cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status PopArray() override {
+    cached_arr_.pop_back();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
+    if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
+        cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNull());
+    } else {
+      RETURN_NOT_OK(builder_->Append(cached_arr_[array_id]->GetView(item_id)));
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
+        cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
+    } else {
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      for (int i = 0; i < repeated; i++) {
+        RETURN_NOT_OK(builder_->Append(val));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->null_count() > 0 &&
+          cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        RETURN_NOT_OK(builder_->AppendNull());
+      } else {
+        RETURN_NOT_OK(builder_->Append(cached_arr_[tmp.array_id]->GetView(tmp.id)));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status AppendNull() override { return builder_->AppendNull(); }
+
+  arrow::Status AppendExistence(bool is_exist) { return builder_->Append(is_exist); }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
+    auto status = builder_->Finish(out_);
+    return status;
+  }
+  
+  arrow::Status Reserve(uint64_t len) override {
+    //builder_->Reserve(len);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Reset() override {
+    builder_->Reset();
+    return arrow::Status::OK();
+  }
+
+ private:
+  using BuilderType_ = typename arrow::TypeTraits<DataType>::BuilderType;
+  using ArrayType_ = typename arrow::TypeTraits<DataType>::ArrayType;
+  std::unique_ptr<BuilderType_> builder_;
+  std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
+  arrow::compute::ExecContext* ctx_;
+  AppenderType type_;
+  bool has_null_ = false;
+};
+
+template <typename DataType>
+class UnsafeArrayAppender<DataType, enable_if_decimal<DataType>> : public AppenderBase {
+ public:
+  UnsafeArrayAppender(arrow::compute::ExecContext* ctx,
+                std::shared_ptr<arrow::DataType> data_type, AppenderType type = left)
+      : ctx_(ctx), type_(type) {
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    arrow::MakeBuilder(ctx_->memory_pool(), data_type, &array_builder);
+    builder_.reset(arrow::internal::checked_cast<BuilderType_*>(array_builder.release()));
+  }
+  ~UnsafeArrayAppender() {}
+
+  AppenderType GetType() override { return type_; }
+  arrow::Status AddArray(const std::shared_ptr<arrow::Array>& arr) override {
+    auto typed_arr_ = std::dynamic_pointer_cast<ArrayType_>(arr);
+    cached_arr_.emplace_back(typed_arr_);
+    if (typed_arr_->null_count() > 0) has_null_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status PopArray() override {
+    cached_arr_.pop_back();
+    has_null_ = false;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id) override {
+    if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
+      builder_->UnsafeAppendNull();
+    } else {
+      builder_->UnsafeAppend(cached_arr_[array_id]->GetView(item_id));
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const uint16_t& array_id, const uint16_t& item_id,
+                       int repeated) override {
+    if (repeated == 0) return arrow::Status::OK();
+    if (has_null_ && cached_arr_[array_id]->IsNull(item_id)) {
+      RETURN_NOT_OK(builder_->AppendNulls(repeated));
+    } else {
+      auto val = cached_arr_[array_id]->GetView(item_id);
+      for (int i = 0; i < repeated; i++) {
+        RETURN_NOT_OK(builder_->Append(val));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Append(const std::vector<ArrayItemIndex>& index_list) {
+    for (auto tmp : index_list) {
+      if (has_null_ && cached_arr_[tmp.array_id]->IsNull(tmp.id)) {
+        RETURN_NOT_OK(builder_->AppendNull());
+      } else {
+        RETURN_NOT_OK(builder_->Append(cached_arr_[tmp.array_id]->GetView(tmp.id)));
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status AppendNull() override { return builder_->AppendNull(); }
+
+  arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
+    auto status = builder_->Finish(out_);
+    return status;
+  }
+
+  arrow::Status Reserve(uint64_t len) override {
+    builder_->Reserve(len);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Reset() override {
+    builder_->Reset();
+    return arrow::Status::OK();
+  }
+
+ private:
+  using BuilderType_ = typename arrow::TypeTraits<DataType>::BuilderType;
+  using ArrayType_ = typename arrow::TypeTraits<DataType>::ArrayType;
+  std::unique_ptr<BuilderType_> builder_;
+  std::vector<std::shared_ptr<ArrayType_>> cached_arr_;
+  arrow::compute::ExecContext* ctx_;
+  AppenderType type_;
+  bool has_null_ = false;
+};
+
+#define PROCESS_SUPPORTED_TYPES(PROCESS) \
+  PROCESS(arrow::BooleanType)            \
+  PROCESS(arrow::UInt8Type)              \
+  PROCESS(arrow::Int8Type)               \
+  PROCESS(arrow::UInt16Type)             \
+  PROCESS(arrow::Int16Type)              \
+  PROCESS(arrow::UInt32Type)             \
+  PROCESS(arrow::Int32Type)              \
+  PROCESS(arrow::UInt64Type)             \
+  PROCESS(arrow::Int64Type)              \
+  PROCESS(arrow::FloatType)              \
+  PROCESS(arrow::DoubleType)             \
+  PROCESS(arrow::Date32Type)             \
+  PROCESS(arrow::Date64Type)             \
+  PROCESS(arrow::StringType)
+static arrow::Status MakeUnsafeAppender(arrow::compute::ExecContext* ctx,
+                                  std::shared_ptr<arrow::DataType> type,
+                                  AppenderBase::AppenderType appender_type,
+                                  std::shared_ptr<AppenderBase>* out) {
+  switch (type->id()) {
+#define PROCESS(InType)                                                         \
+  case InType::type_id: {                                                       \
+    auto app_ptr = std::make_shared<UnsafeArrayAppender<InType>>(ctx, appender_type); \
+    *out = std::dynamic_pointer_cast<AppenderBase>(app_ptr);                    \
+  } break;
+    PROCESS_SUPPORTED_TYPES(PROCESS)
+#undef PROCESS
+    case arrow::Decimal128Type::type_id: {
+      auto app_ptr = std::make_shared<UnsafeArrayAppender<arrow::Decimal128Type>>(
+          ctx, type, appender_type);
+      *out = std::dynamic_pointer_cast<AppenderBase>(app_ptr);
+    } break;
+    default: {
+      return arrow::Status::NotImplemented("MakeAppender type not supported, type is ",
+                                           type->ToString());
+    } break;
+  }
+  return arrow::Status::OK();
+}
+#undef PROCESS_SUPPORTED_TYPES
+
+
 
 }  // namespace extra
 }  // namespace arrowcompute

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/array_appender.h
@@ -473,14 +473,13 @@ static arrow::Status MakeAppender(arrow::compute::ExecContext* ctx,
 }
 #undef PROCESS_SUPPORTED_TYPES
 
-
 /// unsafe appender ////
 template <typename DataType, typename Enable = void>
 class UnsafeArrayAppender {};
 
-
 template <typename DataType>
-class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>> : public AppenderBase {
+class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>>
+    : public AppenderBase {
  public:
   UnsafeArrayAppender(arrow::compute::ExecContext* ctx, AppenderType type = left)
       : ctx_(ctx), type_(type) {
@@ -520,13 +519,13 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>> : public
     if (repeated == 0) return arrow::Status::OK();
     if (has_null_ && cached_arr_[array_id]->null_count() > 0 &&
         cached_arr_[array_id]->IsNull(item_id)) {
-      //TODO: unloop here and use unsafeappend
+      // TODO: unloop here and use unsafeappend
       RETURN_NOT_OK(builder_->AppendNulls(repeated));
     } else {
       auto val = cached_arr_[array_id]->GetView(item_id);
       std::vector<CType> values;
       values.resize(repeated, val);
-      //TODO: unloop here and use unsafeappend
+      // TODO: unloop here and use unsafeappend
       RETURN_NOT_OK(builder_->AppendValues(values.data(), repeated));
     }
     return arrow::Status::OK();
@@ -545,9 +544,9 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>> : public
   }
 
   arrow::Status AppendNull() override {
-    //TODO: use unsafe append
-    return builder_->AppendNull(); 
-    }
+    // TODO: use unsafe append
+    return builder_->AppendNull();
+  }
 
   arrow::Status Finish(std::shared_ptr<arrow::Array>* out_) override {
     auto status = builder_->Finish(out_);
@@ -558,7 +557,7 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>> : public
     builder_->Reserve(len);
     return arrow::Status::OK();
   }
-  
+
   arrow::Status Reset() override {
     builder_->Reset();
     return arrow::Status::OK();
@@ -575,7 +574,7 @@ class UnsafeArrayAppender<DataType, enable_if_number_or_date<DataType>> : public
   bool has_null_ = false;
 };
 
-//TODO(): this is a fake unsafeappende for string array
+// TODO(): this is a fake unsafeappende for string array
 template <typename DataType>
 class UnsafeArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
     : public AppenderBase {
@@ -646,9 +645,9 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
     auto status = builder_->Finish(out_);
     return status;
   }
-  
+
   arrow::Status Reserve(uint64_t len) override {
-    //builder_->Reserve(len);
+    // builder_->Reserve(len);
     return arrow::Status::OK();
   }
 
@@ -667,9 +666,10 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_string_like<DataType>>
   bool has_null_ = false;
 };
 
-//TOOD(): this is a fake unsafeappender for boolean array
+// TOOD(): this is a fake unsafeappender for boolean array
 template <typename DataType>
-class UnsafeArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public AppenderBase {
+class UnsafeArrayAppender<DataType, arrow::enable_if_boolean<DataType>>
+    : public AppenderBase {
  public:
   UnsafeArrayAppender(arrow::compute::ExecContext* ctx, AppenderType type = left)
       : ctx_(ctx), type_(type) {
@@ -739,9 +739,9 @@ class UnsafeArrayAppender<DataType, arrow::enable_if_boolean<DataType>> : public
     auto status = builder_->Finish(out_);
     return status;
   }
-  
+
   arrow::Status Reserve(uint64_t len) override {
-    //builder_->Reserve(len);
+    // builder_->Reserve(len);
     return arrow::Status::OK();
   }
 
@@ -764,7 +764,8 @@ template <typename DataType>
 class UnsafeArrayAppender<DataType, enable_if_decimal<DataType>> : public AppenderBase {
  public:
   UnsafeArrayAppender(arrow::compute::ExecContext* ctx,
-                std::shared_ptr<arrow::DataType> data_type, AppenderType type = left)
+                      std::shared_ptr<arrow::DataType> data_type,
+                      AppenderType type = left)
       : ctx_(ctx), type_(type) {
     std::unique_ptr<arrow::ArrayBuilder> array_builder;
     arrow::MakeBuilder(ctx_->memory_pool(), data_type, &array_builder);
@@ -863,14 +864,14 @@ class UnsafeArrayAppender<DataType, enable_if_decimal<DataType>> : public Append
   PROCESS(arrow::Date64Type)             \
   PROCESS(arrow::StringType)
 static arrow::Status MakeUnsafeAppender(arrow::compute::ExecContext* ctx,
-                                  std::shared_ptr<arrow::DataType> type,
-                                  AppenderBase::AppenderType appender_type,
-                                  std::shared_ptr<AppenderBase>* out) {
+                                        std::shared_ptr<arrow::DataType> type,
+                                        AppenderBase::AppenderType appender_type,
+                                        std::shared_ptr<AppenderBase>* out) {
   switch (type->id()) {
-#define PROCESS(InType)                                                         \
-  case InType::type_id: {                                                       \
+#define PROCESS(InType)                                                               \
+  case InType::type_id: {                                                             \
     auto app_ptr = std::make_shared<UnsafeArrayAppender<InType>>(ctx, appender_type); \
-    *out = std::dynamic_pointer_cast<AppenderBase>(app_ptr);                    \
+    *out = std::dynamic_pointer_cast<AppenderBase>(app_ptr);                          \
   } break;
     PROCESS_SUPPORTED_TYPES(PROCESS)
 #undef PROCESS
@@ -887,8 +888,6 @@ static arrow::Status MakeUnsafeAppender(arrow::compute::ExecContext* ctx,
   return arrow::Status::OK();
 }
 #undef PROCESS_SUPPORTED_TYPES
-
-
 
 }  // namespace extra
 }  // namespace arrowcompute

--- a/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
+++ b/native-sql-engine/cpp/src/codegen/arrow_compute/ext/sort_kernel.cc
@@ -664,7 +664,7 @@ extern "C" void MakeCodeGen(arrow::compute::ExecContext* ctx,
       for (int i = 0; i < col_num_; i++) {
         auto field = schema->field(i);
         std::shared_ptr<AppenderBase> appender;
-        THROW_NOT_OK(MakeAppender(ctx_, field->type(), appender_type, &appender));
+        THROW_NOT_OK(MakeUnsafeAppender(ctx_, field->type(), appender_type, &appender));
         appender_list_.push_back(appender);
       }
       for (int i = 0; i < col_num_; i++) {
@@ -693,6 +693,7 @@ extern "C" void MakeCodeGen(arrow::compute::ExecContext* ctx,
                                                             : (total_length_ - offset_);
       uint64_t count = 0;
       for (int i = 0; i < col_num_; i++) {
+        RETURN_NOT_OK(appender_list_[i]->Reserve(length));
         while (count < length) {
           auto item = indices_begin_ + offset_ + count++;
           RETURN_NOT_OK(appender_list_[i]->Append(item->array_id, item->id));


### PR DESCRIPTION

## What changes were proposed in this pull request?
This patch adds an unsafe appender which will reserve space before builder array. 
The boolean builder is not touched as only malloc small sized memory
The string builder are not touched as it's diffcult to pre-allocate the space

On my 2node env this can improve TPC-DS performance by ~5%
This approach is applied to Sort operator only. 
 
related: #170 
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>



## How was this patch tested?
locally verified

