### PR TITLE
[NSE-229] Fix the deprecated code warning in shuffle_split_test

### DIFF
--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -17,6 +17,7 @@
 
 #include <arrow/compute/api.h>
 #include <arrow/io/api.h>
+#include <arrow/datum.h>
 #include <arrow/ipc/reader.h>
 #include <arrow/ipc/util.h>
 #include <arrow/record_batch.h>
@@ -123,10 +124,9 @@ class SplitterTest : public ::testing::Test {
 
     auto cntx = arrow::compute::ExecContext();
     std::shared_ptr<arrow::RecordBatch> res;
-    auto maybe_res = arrow::compute::Take(*input_batch, *take_idx,
-                                          arrow::compute::TakeOptions{}, &cntx);
-    res = *std::move(maybe_res);
-    return res;
+    ARROW_ASSIGN_OR_RAISE(arrow::Datum result, arrow::compute::Take(arrow::Datum(input_batch), arrow::Datum(take_idx),
+                                          arrow::compute::TakeOptions{}, &cntx));
+    return result.record_batch();
   }
 
   arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchReader>>

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -16,8 +16,8 @@
  */
 
 #include <arrow/compute/api.h>
-#include <arrow/io/api.h>
 #include <arrow/datum.h>
+#include <arrow/io/api.h>
 #include <arrow/ipc/reader.h>
 #include <arrow/ipc/util.h>
 #include <arrow/record_batch.h>
@@ -125,8 +125,9 @@ class SplitterTest : public ::testing::Test {
     auto cntx = arrow::compute::ExecContext();
     std::shared_ptr<arrow::RecordBatch> res;
     ARROW_ASSIGN_OR_RAISE(
-      arrow::Datum result, arrow::compute::Take(arrow::Datum(input_batch),
-       arrow::Datum(take_idx), arrow::compute::TakeOptions{}, &cntx));
+        arrow::Datum result,
+        arrow::compute::Take(arrow::Datum(input_batch), arrow::Datum(take_idx),
+                             arrow::compute::TakeOptions{}, &cntx));
     return result.record_batch();
   }
 

--- a/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
+++ b/native-sql-engine/cpp/src/tests/shuffle_split_test.cc
@@ -124,8 +124,9 @@ class SplitterTest : public ::testing::Test {
 
     auto cntx = arrow::compute::ExecContext();
     std::shared_ptr<arrow::RecordBatch> res;
-    ARROW_ASSIGN_OR_RAISE(arrow::Datum result, arrow::compute::Take(arrow::Datum(input_batch), arrow::Datum(take_idx),
-                                          arrow::compute::TakeOptions{}, &cntx));
+    ARROW_ASSIGN_OR_RAISE(
+      arrow::Datum result, arrow::compute::Take(arrow::Datum(input_batch),
+       arrow::Datum(take_idx), arrow::compute::TakeOptions{}, &cntx));
     return result.record_batch();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix [#229](https://github.com/oap-project/native-sql-engine/issues/229)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

