### PR TITLE
[NSE-341] fix maven build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.1.1</spark.version>
     <arrow.version>4.0.0</arrow.version>
+    <arrow-memory.artifact>arrow-memory-netty</arrow-memory.artifact>
     <hadoop.version>2.7.4</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fixed the build failure on v2 with -Phadoop-3.2
fixed: https://github.com/oap-project/native-sql-engine/issues/341


## How was this patch tested?

locally tested

